### PR TITLE
Add functionality for sending out mail

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -22,6 +22,7 @@ import no.nav.emottak.publisher.MailPublisher
 import no.nav.emottak.receiver.PayloadReceiver
 import no.nav.emottak.receiver.SignalReceiver
 import no.nav.emottak.repository.PayloadRepository
+import no.nav.emottak.smtp.MailSender
 import no.nav.emottak.util.EbmsProviderClient
 import no.nav.emottak.util.coroutineScope
 import org.slf4j.LoggerFactory
@@ -41,7 +42,8 @@ fun main() = SuspendApp {
             val signalReceiver = SignalReceiver(deps.kafkaReceiver)
             val payloadRepository = PayloadRepository(deps.payloadDatabase)
             val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository)
-            val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver)
+            val mailSender = MailSender(deps.session)
+            val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 
             val server = config().server
 
@@ -53,7 +55,7 @@ fun main() = SuspendApp {
             )
 
             val scope = coroutineScope(coroutineContext)
-            messageProcessor.processPayloadAndSignalMessages(scope)
+            messageProcessor.processMailRoutingMessages(scope)
 
             scheduleProcessMailMessages(mailProcessor)
 

--- a/src/main/kotlin/no/nav/emottak/model/MailMetadata.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MailMetadata.kt
@@ -1,0 +1,5 @@
+package no.nav.emottak.model
+
+data class MailMetadata(
+    val addresses: String
+)

--- a/src/main/kotlin/no/nav/emottak/model/MailRoutingMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MailRoutingMessage.kt
@@ -1,3 +1,3 @@
 package no.nav.emottak.model
 
-interface Message
+interface MailRoutingMessage

--- a/src/main/kotlin/no/nav/emottak/model/MailRoutingPayloadMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MailRoutingPayloadMessage.kt
@@ -1,0 +1,6 @@
+package no.nav.emottak.model
+
+data class MailRoutingPayloadMessage(
+    val mailMetadata: MailMetadata,
+    val payloadMessage: PayloadMessage
+) : MailRoutingMessage

--- a/src/main/kotlin/no/nav/emottak/model/MailRoutingSignalMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MailRoutingSignalMessage.kt
@@ -1,0 +1,6 @@
+package no.nav.emottak.model
+
+class MailRoutingSignalMessage(
+    val mailMetadata: MailMetadata,
+    val signalMessage: SignalMessage
+) : MailRoutingMessage

--- a/src/main/kotlin/no/nav/emottak/model/MessageType.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MessageType.kt
@@ -1,0 +1,6 @@
+package no.nav.emottak.model
+
+enum class MessageType {
+    SIGNAL,
+    PAYLOAD
+}

--- a/src/main/kotlin/no/nav/emottak/model/PayloadMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/PayloadMessage.kt
@@ -6,4 +6,4 @@ data class PayloadMessage(
     val messageId: Uuid,
     val envelope: ByteArray,
     val payloads: List<Payload>
-) : MailRoutingMessage
+)

--- a/src/main/kotlin/no/nav/emottak/model/PayloadMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/PayloadMessage.kt
@@ -6,4 +6,4 @@ data class PayloadMessage(
     val messageId: Uuid,
     val envelope: ByteArray,
     val payloads: List<Payload>
-) : Message
+) : MailRoutingMessage

--- a/src/main/kotlin/no/nav/emottak/model/SignalMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/SignalMessage.kt
@@ -5,4 +5,4 @@ import kotlin.uuid.Uuid
 data class SignalMessage(
     val messageId: Uuid,
     val envelope: ByteArray
-) : MailRoutingMessage
+)

--- a/src/main/kotlin/no/nav/emottak/model/SignalMessage.kt
+++ b/src/main/kotlin/no/nav/emottak/model/SignalMessage.kt
@@ -5,4 +5,4 @@ import kotlin.uuid.Uuid
 data class SignalMessage(
     val messageId: Uuid,
     val envelope: ByteArray
-) : Message
+) : MailRoutingMessage

--- a/src/main/kotlin/no/nav/emottak/processor/MessageProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MessageProcessor.kt
@@ -2,42 +2,71 @@ package no.nav.emottak.processor
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import no.nav.emottak.log
-import no.nav.emottak.model.Message
+import no.nav.emottak.model.MailMetadata
+import no.nav.emottak.model.MailRoutingMessage
+import no.nav.emottak.model.MailRoutingPayloadMessage
+import no.nav.emottak.model.MailRoutingSignalMessage
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
 import no.nav.emottak.receiver.PayloadReceiver
 import no.nav.emottak.receiver.SignalReceiver
+import no.nav.emottak.smtp.MailSender
 
 class MessageProcessor(
     private val payloadReceiver: PayloadReceiver,
-    private val signalReceiver: SignalReceiver
+    private val signalReceiver: SignalReceiver,
+    private val mailSender: MailSender
 ) {
-    fun processPayloadAndSignalMessages(scope: CoroutineScope) =
-        merge(
-            payloadReceiver.receivePayloadMessages(),
-            signalReceiver.receiveSignalMessages()
-        )
-            .onEach(::processMessage)
+    fun processMailRoutingMessages(scope: CoroutineScope) =
+        mailRoutingMessageFlow()
+            .onEach { message -> processAndSendMessage(scope, message) }
             .flowOn(Dispatchers.IO)
             .launchIn(scope)
 
-    private fun processMessage(message: Message) {
+    private fun mailRoutingMessageFlow(): Flow<MailRoutingMessage> =
+        merge(
+            payloadReceiver.receiveMailRoutingMessages(),
+            signalReceiver.receiveMailRoutingMessages()
+        )
+
+    private fun processAndSendMessage(scope: CoroutineScope, message: MailRoutingMessage) {
         when (message) {
-            is PayloadMessage -> processPayloadMessage(message)
-            is SignalMessage -> processSignalMessage(message)
+            is MailRoutingSignalMessage -> processAndSendSignalMessage(
+                scope,
+                message.mailMetadata,
+                message.signalMessage
+            )
+
+            is MailRoutingPayloadMessage -> processAndSendPayloadMessage(
+                scope,
+                message.mailMetadata,
+                message.payloadMessage
+            )
         }
     }
 
-    private fun processPayloadMessage(message: PayloadMessage) {
-        log.info("Processed payload message with reference id: ${message.messageId}")
+    private fun processAndSendSignalMessage(
+        scope: CoroutineScope,
+        mailMetadata: MailMetadata,
+        signalMessage: SignalMessage
+    ) = scope.launch {
+        mailSender.sendSignalMessage(mailMetadata, signalMessage)
     }
+        .also { log.info("Processed and sent signal message with reference id: ${signalMessage.messageId}") }
 
-    private fun processSignalMessage(message: SignalMessage) {
-        log.info("Processed signal message with reference id: ${message.messageId}")
+    private fun processAndSendPayloadMessage(
+        scope: CoroutineScope,
+        mailMetadata: MailMetadata,
+        payloadMessage: PayloadMessage
+    ) = scope.launch {
+        mailSender.sendPayloadMessage(mailMetadata, payloadMessage)
     }
+        .also { log.info("Processed and sent payload message with reference id: ${payloadMessage.messageId}") }
 }

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -46,26 +46,24 @@ class MailSender(private val session: Session) {
         MimeMessage(session).apply {
             setFrom(InternetAddress("smtp-transport@nav.no"))
             addRecipient(TO, InternetAddress("kristian.frohlich@nav.no"))
-            setHeader("Content-Type", "application/soap+xml")
-            setText(String(signalMessage.envelope))
+            setContent(signalMessage.envelope, "application/soap+xml; charset=UTF-8")
         }
 
     private fun createMimeMultipartMessage(metadata: MailMetadata, payloadMessage: PayloadMessage): MimeMessage =
         MimeMessage(session).apply {
             setFrom(InternetAddress("smtp-transport@nav.no"))
             addRecipient(TO, InternetAddress("kristian.frohlich@nav.no"))
-            setHeader("Content-Type", "application/soap+xml")
 
             setContent(
                 MimeMultipart().apply {
-                    addBodyPart(createTextPart(payloadMessage))
+                    addBodyPart(createContentPart(payloadMessage))
                     createPayloadParts(payloadMessage).forEach(::addBodyPart)
                 }
             )
         }
 
-    private fun createTextPart(payloadMessage: PayloadMessage): MimeBodyPart =
-        MimeBodyPart().apply { setText(String(payloadMessage.envelope)) }
+    private fun createContentPart(payloadMessage: PayloadMessage): MimeBodyPart =
+        MimeBodyPart().apply { setContent(payloadMessage.envelope, "application/soap+xml; charset=UTF-8") }
 
     private fun createPayloadParts(payloadMessage: PayloadMessage): List<MimeBodyPart> =
         payloadMessage.payloads.map { payload ->

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -1,20 +1,73 @@
 package no.nav.emottak.smtp
 
+import arrow.core.raise.catch
 import jakarta.mail.Message.RecipientType.TO
 import jakarta.mail.Session
 import jakarta.mail.Transport
 import jakarta.mail.internet.InternetAddress
+import jakarta.mail.internet.MimeBodyPart
 import jakarta.mail.internet.MimeMessage
+import jakarta.mail.internet.MimeMultipart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nav.emottak.log
+import no.nav.emottak.model.MailMetadata
+import no.nav.emottak.model.PayloadMessage
+import no.nav.emottak.model.SignalMessage
 
 class MailSender(private val session: Session) {
 
-    fun sendMessage() {
-        val msg = MimeMessage(session)
-        msg.setFrom(InternetAddress("send@test.test"))
-        msg.addRecipient(TO, InternetAddress("test@test.test"))
-        msg.subject = "Email sent to GreenMail via plain JavaMail"
-        msg.setText("Fetch me via POP3")
+    suspend fun sendSignalMessage(metadata: MailMetadata, signalMessage: SignalMessage) =
+        sendMessage(
+            metadata,
+            createMimeMessage(metadata, signalMessage),
+            "signal"
+        )
 
-        Transport.send(msg)
-    }
+    suspend fun sendPayloadMessage(metadata: MailMetadata, payloadMessage: PayloadMessage) =
+        sendMessage(
+            metadata,
+            createMimeMultipartMessage(metadata, payloadMessage),
+            "payload"
+        )
+
+    private suspend fun sendMessage(metadata: MailMetadata, message: MimeMessage, messageType: String) =
+        withContext(Dispatchers.IO) {
+            catch({ Transport.send(message) }) { e: Exception ->
+                log.error("Failed to send $messageType message: ${e.stackTraceToString()}")
+            }
+        }
+
+    private fun createMimeMessage(metadata: MailMetadata, signalMessage: SignalMessage): MimeMessage =
+        MimeMessage(session).apply {
+            setFrom(InternetAddress("smtp-transport@nav.no"))
+            addRecipient(TO, InternetAddress("kristian.frohlich@nav.no"))
+            setHeader("Content-Type", "application/soap+xml")
+            setText(String(signalMessage.envelope))
+        }
+
+    private fun createMimeMultipartMessage(metadata: MailMetadata, payloadMessage: PayloadMessage): MimeMessage =
+        MimeMessage(session).apply {
+            setFrom(InternetAddress("smtp-transport@nav.no"))
+            addRecipient(TO, InternetAddress("kristian.frohlich@nav.no"))
+            setHeader("Content-Type", "application/soap+xml")
+
+            setContent(
+                MimeMultipart().apply {
+                    addBodyPart(createTextPart(payloadMessage))
+                    createPayloadParts(payloadMessage).forEach(::addBodyPart)
+                }
+            )
+        }
+
+    private fun createTextPart(payloadMessage: PayloadMessage): MimeBodyPart =
+        MimeBodyPart().apply { setText(String(payloadMessage.envelope)) }
+
+    private fun createPayloadParts(payloadMessage: PayloadMessage): List<MimeBodyPart> =
+        payloadMessage.payloads.map { payload ->
+            MimeBodyPart().apply {
+                setContent(String(payload.content), payload.contentType)
+                contentID = payload.contentId
+            }
+        }
 }

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.smtp
 
 import arrow.core.raise.catch
 import jakarta.mail.Message.RecipientType.TO
+import jakarta.mail.MessagingException
 import jakarta.mail.Session
 import jakarta.mail.Transport
 import jakarta.mail.internet.InternetAddress
@@ -12,6 +13,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.emottak.log
 import no.nav.emottak.model.MailMetadata
+import no.nav.emottak.model.MessageType
+import no.nav.emottak.model.MessageType.PAYLOAD
+import no.nav.emottak.model.MessageType.SIGNAL
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
 
@@ -21,19 +25,19 @@ class MailSender(private val session: Session) {
         sendMessage(
             metadata,
             createMimeMessage(metadata, signalMessage),
-            "signal"
+            SIGNAL
         )
 
     suspend fun sendPayloadMessage(metadata: MailMetadata, payloadMessage: PayloadMessage) =
         sendMessage(
             metadata,
             createMimeMultipartMessage(metadata, payloadMessage),
-            "payload"
+            PAYLOAD
         )
 
-    private suspend fun sendMessage(metadata: MailMetadata, message: MimeMessage, messageType: String) =
+    private suspend fun sendMessage(metadata: MailMetadata, message: MimeMessage, messageType: MessageType) =
         withContext(Dispatchers.IO) {
-            catch({ Transport.send(message) }) { e: Exception ->
+            catch({ Transport.send(message) }) { e: MessagingException ->
                 log.error("Failed to send $messageType message: ${e.stackTraceToString()}")
             }
         }

--- a/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
+++ b/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
@@ -1,0 +1,9 @@
+package no.nav.emottak.util
+
+import io.github.nomisRev.kafka.receiver.ReceiverRecord
+
+fun <K, V> ReceiverRecord<K, V>.getHeaderValueAsString(value: String): String =
+    when (val header = headers().lastHeader(value)) {
+        null -> ""
+        else -> String(header.value())
+    }

--- a/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
+++ b/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
@@ -1,9 +1,10 @@
 package no.nav.emottak.util
 
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
+import no.nav.emottak.log
 
 fun <K, V> ReceiverRecord<K, V>.getHeaderValueAsString(value: String): String =
     when (val header = headers().lastHeader(value)) {
-        null -> ""
+        null -> "".also { log.warn("Header missing: $value") }
         else -> String(header.value())
     }

--- a/src/test/kotlin/no/nav/emottak/receiver/PayloadReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/receiver/PayloadReceiverSpec.kt
@@ -65,10 +65,11 @@ class PayloadReceiverSpec : KafkaSpec(
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
                         ebmsProviderClient
                     )
-                    val payloadMessages = receiver.receivePayloadMessages()
+                    val mailRoutingMessages = receiver.receiveMailRoutingMessages()
 
-                    payloadMessages.test {
-                        val payloadMessage = awaitItem()
+                    mailRoutingMessages.test {
+                        val mailRoutingMessage = awaitItem()
+                        val payloadMessage = mailRoutingMessage.payloadMessage
                         payloadMessage.messageId shouldBe referenceId
                         payloadMessage.envelope shouldBe content
                         payloadMessage.payloads shouldHaveSize 1

--- a/src/test/kotlin/no/nav/emottak/receiver/SignalReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/receiver/SignalReceiverSpec.kt
@@ -46,10 +46,11 @@ class SignalReceiverSpec : KafkaSpec(
                 }
 
                 val receiver = SignalReceiver(kafkaReceiver(config.kafka, AutoOffsetReset.Earliest))
-                val signalMessages = receiver.receiveSignalMessages()
+                val mailRoutingMessages = receiver.receiveMailRoutingMessages()
 
-                signalMessages.test {
-                    val signalMessage = awaitItem()
+                mailRoutingMessages.test {
+                    val mailRoutingMessage = awaitItem()
+                    val signalMessage = mailRoutingMessage.signalMessage
                     signalMessage.messageId shouldBe referenceId
                     signalMessage.envelope shouldBe content
                 }

--- a/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
@@ -1,25 +1,53 @@
 package no.nav.emottak.smtp
 
+import arrow.fx.coroutines.resourceScope
+import com.icegreen.greenmail.util.GreenMail
+import com.icegreen.greenmail.util.ServerSetupTest.SMTP_POP3
 import io.kotest.core.spec.style.StringSpec
 import no.nav.emottak.config
+import no.nav.emottak.model.MailMetadata
+import no.nav.emottak.model.Payload
+import no.nav.emottak.model.PayloadMessage
+import no.nav.emottak.model.SignalMessage
+import no.nav.emottak.session
+import kotlin.uuid.Uuid
 
 class MailSenderSpec : StringSpec({
+    lateinit var mailSender: MailSender
+    lateinit var greenMail: GreenMail
     val config = config()
 
-    // "test send mail" {
-    //     resourceScope {
-    //         val session = session(config.smtp)
-    //
-    //         val greenMail = GreenMail(SMTP_POP3)
-    //         greenMail.start()
-    //
-    //         val smtp = config.smtp
-    //         greenMail.setUser(smtp.username.value, smtp.username.value, smtp.password.value)
-    //
-    //         val mailSender = MailSender(session)
-    //         mailSender.sendMessage()
-    //
-    //         greenMail.stop()
-    //     }
-    // }
+    beforeSpec {
+        val session = session(config.smtp)
+        greenMail = GreenMail(SMTP_POP3).apply {
+            start()
+            setUser(config.smtp.username.value, config.smtp.username.value, config.smtp.password.value)
+        }
+        mailSender = MailSender(session)
+    }
+
+    "send signal message" {
+        resourceScope {
+            val metadata = MailMetadata("signal")
+            val message = SignalMessage(Uuid.random(), getEnvelope().toByteArray())
+
+            mailSender.sendSignalMessage(metadata, message)
+        }
+    }
+
+    "send payload message" {
+        resourceScope {
+            val metadata = MailMetadata("payload")
+            val message = PayloadMessage(Uuid.random(), getEnvelope().toByteArray(), listOf(getPayload()))
+
+            mailSender.sendPayloadMessage(metadata, message)
+        }
+    }
+
+    afterSpec { greenMail.stop() }
 })
+
+private fun getEnvelope() =
+    """<?xml version="1.0" encoding="UTF-8"?><soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope"><soap:Body><message>Hello</message></soap:Body></soap:Envelope>"""
+
+private fun getPayload() = Payload(Uuid.random(), "content", "text/plain", "content".toByteArray())

--- a/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
@@ -1,29 +1,25 @@
 package no.nav.emottak.smtp
 
-import arrow.fx.coroutines.resourceScope
-import com.icegreen.greenmail.util.GreenMail
-import com.icegreen.greenmail.util.ServerSetupTest.SMTP_POP3
 import io.kotest.core.spec.style.StringSpec
 import no.nav.emottak.config
-import no.nav.emottak.session
 
 class MailSenderSpec : StringSpec({
     val config = config()
 
-    "test send mail" {
-        resourceScope {
-            val session = session(config.smtp)
-
-            val greenMail = GreenMail(SMTP_POP3)
-            greenMail.start()
-
-            val smtp = config.smtp
-            greenMail.setUser(smtp.username.value, smtp.username.value, smtp.password.value)
-
-            val mailSender = MailSender(session)
-            mailSender.sendMessage()
-
-            greenMail.stop()
-        }
-    }
+    // "test send mail" {
+    //     resourceScope {
+    //         val session = session(config.smtp)
+    //
+    //         val greenMail = GreenMail(SMTP_POP3)
+    //         greenMail.start()
+    //
+    //         val smtp = config.smtp
+    //         greenMail.setUser(smtp.username.value, smtp.username.value, smtp.password.value)
+    //
+    //         val mailSender = MailSender(session)
+    //         mailSender.sendMessage()
+    //
+    //         greenMail.stop()
+    //     }
+    // }
 })


### PR DESCRIPTION
Regarding sending of mail:

- We don't want to spam real mail addresses with test mail so initially all mail will land in my NAV mailbox
- This also servers as validation and verification of the created mails - if everything looks as expected
- When we enable actual sending to the correct addresses the Kafka header will be used to retrieve all recipients