### PR TITLE
Event registration for all known event types

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -43,9 +43,10 @@ fun main() = SuspendApp {
             val scope = coroutineScope(coroutineContext)
             val eventScope = coroutineScope(Dispatchers.IO)
 
+            val eventPublisherClient = EventPublisherClient(config().kafka)
             val eventLoggingService = eventLoggingService(
                 eventScope,
-                EventLoggingService(EventPublisherClient(config().kafka))
+                EventLoggingService(eventPublisherClient)
             )
 
             val mailPublisher = MailPublisher(deps.kafkaPublisher, eventLoggingService)

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -10,6 +10,7 @@ import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import no.nav.emottak.plugin.configureAuthentication
 import no.nav.emottak.plugin.configureCallLogging
@@ -25,6 +26,9 @@ import no.nav.emottak.repository.PayloadRepository
 import no.nav.emottak.smtp.MailSender
 import no.nav.emottak.util.EbmsAsyncClient
 import no.nav.emottak.util.coroutineScope
+import no.nav.emottak.util.eventLoggingService
+import no.nav.emottak.utils.kafka.client.EventPublisherClient
+import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.slf4j.LoggerFactory
 import kotlin.coroutines.coroutineContext
 
@@ -36,13 +40,21 @@ fun main() = SuspendApp {
             val deps = initDependencies()
             deps.migrationService.migrate()
 
-            val mailPublisher = MailPublisher(deps.kafkaPublisher)
+            val scope = coroutineScope(coroutineContext)
+            val eventScope = coroutineScope(Dispatchers.IO)
+
+            val eventLoggingService = eventLoggingService(
+                eventScope,
+                EventLoggingService(EventPublisherClient(config().kafka))
+            )
+
+            val mailPublisher = MailPublisher(deps.kafkaPublisher, eventLoggingService)
             val ebmsAsyncClient = EbmsAsyncClient(deps.httpClient)
-            val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient)
-            val signalReceiver = SignalReceiver(deps.kafkaReceiver)
-            val payloadRepository = PayloadRepository(deps.payloadDatabase)
-            val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository)
-            val mailSender = MailSender(deps.session)
+            val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient, eventLoggingService)
+            val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
+            val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
+            val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository, eventLoggingService)
+            val mailSender = MailSender(deps.session, eventLoggingService)
             val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 
             val server = config().server
@@ -54,7 +66,6 @@ fun main() = SuspendApp {
                 module = smtpTransportModule(deps.meterRegistry, payloadRepository)
             )
 
-            val scope = coroutineScope(coroutineContext)
             messageProcessor.processMailRoutingMessages(scope)
 
             scheduleProcessMailMessages(mailProcessor)

--- a/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
@@ -19,6 +19,7 @@ import no.nav.emottak.publisher.MailPublisher
 import no.nav.emottak.repository.PayloadRepository
 import no.nav.emottak.smtp.EmailMsg
 import no.nav.emottak.smtp.MailReader
+import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.toPayloadMessage
 import no.nav.emottak.util.toSignalMessage
 import kotlin.uuid.Uuid
@@ -26,7 +27,8 @@ import kotlin.uuid.Uuid
 class MailProcessor(
     private val store: Store,
     private val mailPublisher: MailPublisher,
-    private val payloadRepository: PayloadRepository
+    private val payloadRepository: PayloadRepository,
+    private val eventLoggingService: ScopedEventLoggingService
 ) {
     fun processMessages(scope: CoroutineScope) =
         readMessages()
@@ -35,7 +37,7 @@ class MailProcessor(
             .launchIn(scope)
 
     private fun readMessages(): Flow<EmailMsg> = autoCloseScope {
-        val mailReader = install(MailReader(config().mail, store, false))
+        val mailReader = install(MailReader(config().mail, store, false, eventLoggingService))
         val messageCount = mailReader.count()
 
         if (messageCount > 0) {

--- a/src/main/kotlin/no/nav/emottak/publisher/MailPublisher.kt
+++ b/src/main/kotlin/no/nav/emottak/publisher/MailPublisher.kt
@@ -19,7 +19,6 @@ class MailPublisher(
 
     suspend fun publishPayloadMessage(message: PayloadMessage) =
         publishMessage(kafka.payloadInTopic, message.messageId, message.envelope)
-            .onSuccess { }
 
     suspend fun publishSignalMessage(message: SignalMessage) =
         publishMessage(kafka.signalInTopic, message.messageId, message.envelope)

--- a/src/main/kotlin/no/nav/emottak/publisher/MailPublisher.kt
+++ b/src/main/kotlin/no/nav/emottak/publisher/MailPublisher.kt
@@ -5,16 +5,21 @@ import no.nav.emottak.config
 import no.nav.emottak.log
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
+import no.nav.emottak.util.ScopedEventLoggingService
+import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_STORING_MESSAGE_IN_QUEUE
+import no.nav.emottak.utils.kafka.model.EventType.MESSAGE_PLACED_IN_QUEUE
 import org.apache.kafka.clients.producer.ProducerRecord
 import kotlin.uuid.Uuid
 
 class MailPublisher(
-    private val kafkaPublisher: KafkaPublisher<String, ByteArray>
+    private val kafkaPublisher: KafkaPublisher<String, ByteArray>,
+    private val eventLoggingService: ScopedEventLoggingService
 ) {
     private val kafka = config().kafkaTopics
 
     suspend fun publishPayloadMessage(message: PayloadMessage) =
         publishMessage(kafka.payloadInTopic, message.messageId, message.envelope)
+            .onSuccess { }
 
     suspend fun publishSignalMessage(message: SignalMessage) =
         publishMessage(kafka.signalInTopic, message.messageId, message.envelope)
@@ -23,8 +28,22 @@ class MailPublisher(
         kafkaPublisher.publishScope {
             publishCatching(toProducerRecord(topic, referenceId, content))
         }
-            .onSuccess { log.info("Published message with reference id $referenceId to: $topic") }
-            .onFailure { log.error("Failed to publish message with reference id: $referenceId") }
+            .onSuccess {
+                log.info("Published message with reference id $referenceId to: $topic")
+
+                eventLoggingService.registerEvent(
+                    MESSAGE_PLACED_IN_QUEUE,
+                    referenceId
+                )
+            }
+            .onFailure {
+                log.error("Failed to publish message with reference id: $referenceId")
+
+                eventLoggingService.registerEvent(
+                    ERROR_WHILE_STORING_MESSAGE_IN_QUEUE,
+                    Exception("Failed to publish message with reference id: $referenceId and content: $content")
+                )
+            }
 
     private fun toProducerRecord(topic: String, referenceId: Uuid, content: ByteArray) =
         ProducerRecord(

--- a/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
@@ -4,6 +4,7 @@ import arrow.core.raise.recover
 import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import no.nav.emottak.PayloadError
 import no.nav.emottak.config
@@ -13,17 +14,31 @@ import no.nav.emottak.model.MailRoutingPayloadMessage
 import no.nav.emottak.model.Payload
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.util.EbmsAsyncClient
+import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.getHeaderValueAsString
+import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_READING_MESSAGE_FROM_QUEUE
+import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_RECEIVING_PAYLOAD_VIA_HTTP
+import no.nav.emottak.utils.kafka.model.EventType.MESSAGE_READ_FROM_QUEUE
+import no.nav.emottak.utils.kafka.model.EventType.PAYLOAD_RECEIVED_VIA_HTTP
 import kotlin.uuid.Uuid
 
 class PayloadReceiver(
     private val kafkaReceiver: KafkaReceiver<String, ByteArray>,
-    private val ebmsAsyncClient: EbmsAsyncClient
+    private val ebmsAsyncClient: EbmsAsyncClient,
+    private val eventLoggingService: ScopedEventLoggingService
 ) {
     private val kafka = config().kafkaTopics
 
     fun receiveMailRoutingMessages(): Flow<MailRoutingPayloadMessage> = kafkaReceiver
         .receive(kafka.payloadOutTopic)
+        .catch { error ->
+            eventLoggingService.registerEvent(
+                ERROR_WHILE_READING_MESSAGE_FROM_QUEUE,
+                Exception(error)
+            )
+
+            throw error
+        }
         .map(::toMailRoutingMessage)
 
     private suspend fun toMailRoutingMessage(record: ReceiverRecord<String, ByteArray>): MailRoutingPayloadMessage {
@@ -37,13 +52,34 @@ class PayloadReceiver(
             getPayloads(referenceId)
         )
 
+        eventLoggingService.registerEvent(
+            MESSAGE_READ_FROM_QUEUE,
+            referenceId
+        )
+
         return MailRoutingPayloadMessage(mailMetadata, payloadMessage)
     }
 
     private suspend fun getPayloads(uuid: Uuid): List<Payload> =
         with(ebmsAsyncClient) {
             recover({
-                getPayloads(uuid).also { log.info("Retrieved ${it.size} payload(s) for reference id: $uuid") }
-            }) { e: PayloadError -> emptyList<Payload>().also { log.error("$e") } }
+                val payloads = getPayloads(uuid)
+                    .also { log.info("Retrieved ${it.size} payload(s) for reference id: $uuid") }
+
+                payloads.map {
+                    eventLoggingService.registerEvent(
+                        PAYLOAD_RECEIVED_VIA_HTTP,
+                        it
+                    )
+                }
+
+                payloads
+            }) { error: PayloadError ->
+                eventLoggingService.registerEvent(
+                    ERROR_WHILE_RECEIVING_PAYLOAD_VIA_HTTP,
+                    Exception(error.toString())
+                )
+                emptyList<Payload>().also { log.error("$error") }
+            }
         }
 }

--- a/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
@@ -3,21 +3,34 @@ package no.nav.emottak.receiver
 import io.github.nomisRev.kafka.receiver.KafkaReceiver
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import no.nav.emottak.config
 import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MailRoutingSignalMessage
 import no.nav.emottak.model.SignalMessage
+import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.getHeaderValueAsString
+import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_READING_MESSAGE_FROM_QUEUE
+import no.nav.emottak.utils.kafka.model.EventType.MESSAGE_READ_FROM_QUEUE
 import kotlin.uuid.Uuid
 
 class SignalReceiver(
-    private val kafkaReceiver: KafkaReceiver<String, ByteArray>
+    private val kafkaReceiver: KafkaReceiver<String, ByteArray>,
+    private val eventLoggingService: ScopedEventLoggingService
 ) {
     private val kafka = config().kafkaTopics
 
     fun receiveMailRoutingMessages(): Flow<MailRoutingSignalMessage> = kafkaReceiver
         .receive(kafka.signalOutTopic)
+        .catch { error ->
+            eventLoggingService.registerEvent(
+                ERROR_WHILE_READING_MESSAGE_FROM_QUEUE,
+                Exception(error)
+            )
+
+            throw error
+        }
         .map(::toMailRoutingMessage)
 
     private fun toMailRoutingMessage(record: ReceiverRecord<String, ByteArray>): MailRoutingSignalMessage {
@@ -27,6 +40,11 @@ class SignalReceiver(
         val signalMessage = SignalMessage(
             Uuid.parse(record.key()),
             record.value()
+        )
+
+        eventLoggingService.registerEvent(
+            MESSAGE_READ_FROM_QUEUE,
+            signalMessage.messageId
         )
 
         return MailRoutingSignalMessage(mailMetadata, signalMessage)

--- a/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
@@ -1,0 +1,126 @@
+package no.nav.emottak.util
+
+import jakarta.mail.internet.MimeMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import no.nav.emottak.log
+import no.nav.emottak.model.Payload
+import no.nav.emottak.utils.kafka.model.Event
+import no.nav.emottak.utils.kafka.model.EventType
+import no.nav.emottak.utils.kafka.service.EventLoggingService
+import no.nav.emottak.utils.serialization.toEventDataJson
+import java.time.Instant
+import kotlin.uuid.Uuid
+
+interface ScopedEventLoggingService {
+    fun registerEvent(eventType: EventType, mimeMessage: MimeMessage)
+    fun registerEvent(eventType: EventType, payload: Payload)
+    fun registerEvent(eventType: EventType, messageId: Uuid)
+
+    fun registerEvent(eventType: EventType, error: Exception)
+}
+
+fun eventLoggingService(scope: CoroutineScope, eventLoggingService: EventLoggingService): ScopedEventLoggingService =
+    object : ScopedEventLoggingService {
+        override fun registerEvent(
+            eventType: EventType,
+            mimeMessage: MimeMessage
+        ) {
+            publishEvent(
+                eventType,
+                mimeMessage.contentID,
+                mimeMessage.messageID,
+                ""
+            )
+        }
+
+        override fun registerEvent(
+            eventType: EventType,
+            payload: Payload
+        ) {
+            publishEvent(
+                eventType,
+                payload.contentId,
+                payload.referenceId.toString(),
+                ""
+            )
+        }
+
+        override fun registerEvent(
+            eventType: EventType,
+            messageId: Uuid
+        ) {
+            publishEvent(
+                eventType,
+                "",
+                messageId.toString(),
+                ""
+            )
+        }
+
+        override fun registerEvent(
+            eventType: EventType,
+            error: Exception
+        ) {
+            publishEvent(
+                eventType,
+                "",
+                "",
+                error.toEventDataJson()
+            )
+        }
+
+        private fun publishEvent(
+            eventType: EventType,
+            contentId: String,
+            messageId: String,
+            eventData: String
+        ) = scope.launch {
+            val event = Event(
+                eventType,
+                Uuid.random(),
+                contentId,
+                messageId,
+                eventData,
+                Instant.now()
+            )
+
+            eventLoggingService.logEvent(event)
+                .onSuccess { log.debug("Event published successfully: {}", event) }
+                .onFailure { log.error("Error while publishing event: ${it.stackTraceToString()}") }
+        }
+    }
+
+fun fakeEventLoggingService(): ScopedEventLoggingService = object : ScopedEventLoggingService {
+    override fun registerEvent(
+        eventType: EventType,
+        mimeMessage: MimeMessage
+    ) {
+        logEvent(eventType)
+    }
+
+    override fun registerEvent(
+        eventType: EventType,
+        payload: Payload
+    ) {
+        logEvent(eventType)
+    }
+
+    override fun registerEvent(
+        eventType: EventType,
+        messageId: Uuid
+    ) {
+        logEvent(eventType)
+    }
+
+    override fun registerEvent(
+        eventType: EventType,
+        error: Exception
+    ) {
+        logEvent(eventType)
+    }
+
+    private fun logEvent(eventType: EventType) {
+        log.info("Registered event: $eventType")
+    }
+}

--- a/src/test/kotlin/no/nav/emottak/SmtpTransportSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/SmtpTransportSpec.kt
@@ -20,6 +20,7 @@ import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import no.nav.emottak.model.Payload
 import no.nav.emottak.repository.PayloadRepository
+import no.nav.emottak.util.fakeEventLoggingService
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
 // Krever kotest-plugin installert i IntelliJ for å kjøre
@@ -33,7 +34,10 @@ class SmtpTransportSpec : StringSpec(
             mockOAuth2Server = MockOAuth2Server().also { it.start(port = config().azureAuth.port.value) }
 
             println("=== Initializing Database ===")
-            payloadRepository = PayloadRepository(payloadDatabase())
+            payloadRepository = PayloadRepository(
+                payloadDatabase(),
+                fakeEventLoggingService()
+            )
             runMigrations()
         }
 

--- a/src/test/kotlin/no/nav/emottak/publisher/MailPublisherSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/publisher/MailPublisherSpec.kt
@@ -13,6 +13,7 @@ import no.nav.emottak.configuration.withKafka
 import no.nav.emottak.kafkaPublisher
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
+import no.nav.emottak.util.fakeEventLoggingService
 import no.nav.emottak.utils.config.SecurityProtocol
 import kotlin.uuid.Uuid
 
@@ -33,7 +34,7 @@ class MailPublisherSpec : KafkaSpec(
         "Publish payload message - message is received" {
             resourceScope {
                 turbineScope {
-                    val publisher = MailPublisher(kafkaPublisher(config.kafka))
+                    val publisher = MailPublisher(kafkaPublisher(config.kafka), fakeEventLoggingService())
 
                     val referenceId = Uuid.random()
                     val content = "payload".toByteArray()
@@ -57,7 +58,7 @@ class MailPublisherSpec : KafkaSpec(
         "Publish signal message - message is received" {
             resourceScope {
                 turbineScope {
-                    val publisher = MailPublisher(kafkaPublisher(config.kafka))
+                    val publisher = MailPublisher(kafkaPublisher(config.kafka), fakeEventLoggingService())
 
                     val referenceId = Uuid.random()
                     val content = "signal".toByteArray()

--- a/src/test/kotlin/no/nav/emottak/receiver/PayloadReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/receiver/PayloadReceiverSpec.kt
@@ -20,6 +20,7 @@ import no.nav.emottak.httpClient
 import no.nav.emottak.httpTokenClient
 import no.nav.emottak.kafkaReceiver
 import no.nav.emottak.util.EbmsAsyncClient
+import no.nav.emottak.util.fakeEventLoggingService
 import no.nav.emottak.utils.config.SecurityProtocol
 import org.apache.kafka.clients.producer.ProducerRecord
 import kotlin.uuid.Uuid
@@ -63,7 +64,8 @@ class PayloadReceiverSpec : KafkaSpec(
                     val ebmsAsyncClient = EbmsAsyncClient(httpClient)
                     val receiver = PayloadReceiver(
                         kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
-                        ebmsAsyncClient
+                        ebmsAsyncClient,
+                        fakeEventLoggingService()
                     )
                     val mailRoutingMessages = receiver.receiveMailRoutingMessages()
 

--- a/src/test/kotlin/no/nav/emottak/receiver/SignalReceiverSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/receiver/SignalReceiverSpec.kt
@@ -10,6 +10,7 @@ import no.nav.emottak.config
 import no.nav.emottak.configuration.Config
 import no.nav.emottak.configuration.withKafka
 import no.nav.emottak.kafkaReceiver
+import no.nav.emottak.util.fakeEventLoggingService
 import no.nav.emottak.utils.config.SecurityProtocol
 import org.apache.kafka.clients.producer.ProducerRecord
 import kotlin.uuid.Uuid
@@ -45,7 +46,10 @@ class SignalReceiverSpec : KafkaSpec(
                     )
                 }
 
-                val receiver = SignalReceiver(kafkaReceiver(config.kafka, AutoOffsetReset.Earliest))
+                val receiver = SignalReceiver(
+                    kafkaReceiver(config.kafka, AutoOffsetReset.Earliest),
+                    fakeEventLoggingService()
+                )
                 val mailRoutingMessages = receiver.receiveMailRoutingMessages()
 
                 mailRoutingMessages.test {

--- a/src/test/kotlin/no/nav/emottak/repository/PayloadRepositorySpec.kt
+++ b/src/test/kotlin/no/nav/emottak/repository/PayloadRepositorySpec.kt
@@ -12,11 +12,15 @@ import no.nav.emottak.PayloadNotFound
 import no.nav.emottak.model.Payload
 import no.nav.emottak.payloadDatabase
 import no.nav.emottak.runMigrations
+import no.nav.emottak.util.fakeEventLoggingService
 import kotlin.uuid.Uuid
 
 class PayloadRepositorySpec : StringSpec(
     {
-        val repository = PayloadRepository(payloadDatabase())
+        val repository = PayloadRepository(
+            payloadDatabase(),
+            fakeEventLoggingService()
+        )
 
         beforeSpec { runMigrations() }
 

--- a/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
@@ -10,6 +10,7 @@ import no.nav.emottak.model.Payload
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
 import no.nav.emottak.session
+import no.nav.emottak.util.fakeEventLoggingService
 import kotlin.uuid.Uuid
 
 class MailSenderSpec : StringSpec({
@@ -23,7 +24,7 @@ class MailSenderSpec : StringSpec({
             start()
             setUser(config.smtp.username.value, config.smtp.username.value, config.smtp.password.value)
         }
-        mailSender = MailSender(session)
+        mailSender = MailSender(session, fakeEventLoggingService())
     }
 
     "send signal message" {


### PR DESCRIPTION
Event registration for the following events are implemented:

MESSAGE_RECEIVED_VIA_SMTP
ERROR_WHILE_RECEIVING_MESSAGE_VIA_SMTP

MESSAGE_SENT_VIA_SMTP
ERROR_WHILE_SENDING_MESSAGE_VIA_SMTP

PAYLOAD_SAVED_INTO_DATABASE
ERROR_WHILE_SAVING_PAYLOAD_INTO_DATABASE

PAYLOAD_READ_FROM_DATABASE
ERROR_WHILE_READING_PAYLOAD_FROM_DATABASE

PAYLOAD_RECEIVED_VIA_HTTP
ERROR_WHILE_RECEIVING_PAYLOAD_VIA_HTTP

MESSAGE_PLACED_IN_QUEUE
ERROR_WHILE_STORING_MESSAGE_IN_QUEUE

MESSAGE_READ_FROM_QUEUE (payload + signal)
ERROR_WHILE_READING_MESSAGE_FROM_QUEUE (payload + signal)

Noteworthy: Introduced usage of _fakes_ to avoid double testing of 3rd party libraries, in this case our own _emottak-utils_ library.



