### PR TITLE
Enable redirect of mail sending

### DIFF
--- a/.nais/smtp-transport-dev.yaml
+++ b/.nais/smtp-transport-dev.yaml
@@ -89,6 +89,8 @@ spec:
       value: "pop3"
     - name: SMTP_INCOMING_USERNAME
       value: "nyebmstest@test-es.nav.no"
+    - name: SMTP_REDIRECT_ADDRESS
+      value: "kristian.frohlich@nav.no"
     - name: POSTGRES_JDBC_URL
       value: "jdbc:postgresql://b27dbvl035.preprod.local:5432/emottak-smtp-transport-payload"
     - name: POSTGRES_MOUNT_PATH

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -62,7 +62,9 @@ data class Smtp(
     val pop3Host: Host,
     val storeProtocol: Protocol,
     val pop3FactoryPort: Port,
-    val pop3FactoryFallback: Boolean
+    val pop3FactoryFallback: Boolean,
+    val smtpFromAddress: String,
+    val smtpRedirectAddress: String
 )
 
 private const val MAIL_SMTP_HOST = "mail.smtp.host"

--- a/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
@@ -13,6 +13,7 @@ import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MailRoutingPayloadMessage
 import no.nav.emottak.model.Payload
 import no.nav.emottak.model.PayloadMessage
+import no.nav.emottak.util.EMAIL_ADDRESSES
 import no.nav.emottak.util.EbmsAsyncClient
 import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.getHeaderValueAsString
@@ -42,7 +43,7 @@ class PayloadReceiver(
         .map(::toMailRoutingMessage)
 
     private suspend fun toMailRoutingMessage(record: ReceiverRecord<String, ByteArray>): MailRoutingPayloadMessage {
-        val mailAddresses = record.getHeaderValueAsString("mailAddresses")
+        val mailAddresses = record.getHeaderValueAsString(EMAIL_ADDRESSES)
         val mailMetadata = MailMetadata(mailAddresses)
 
         val referenceId = Uuid.parse(record.key())

--- a/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
@@ -9,6 +9,7 @@ import no.nav.emottak.config
 import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MailRoutingSignalMessage
 import no.nav.emottak.model.SignalMessage
+import no.nav.emottak.util.EMAIL_ADDRESSES
 import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.getHeaderValueAsString
 import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_READING_MESSAGE_FROM_QUEUE
@@ -34,7 +35,7 @@ class SignalReceiver(
         .map(::toMailRoutingMessage)
 
     private fun toMailRoutingMessage(record: ReceiverRecord<String, ByteArray>): MailRoutingSignalMessage {
-        val mailAddresses = record.getHeaderValueAsString("mailAddresses")
+        val mailAddresses = record.getHeaderValueAsString(EMAIL_ADDRESSES)
         val mailMetadata = MailMetadata(mailAddresses)
 
         val signalMessage = SignalMessage(

--- a/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
+++ b/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
@@ -3,6 +3,8 @@ package no.nav.emottak.util
 import io.github.nomisRev.kafka.receiver.ReceiverRecord
 import no.nav.emottak.log
 
+const val EMAIL_ADDRESSES = "emailAddresses"
+
 fun <K, V> ReceiverRecord<K, V>.getHeaderValueAsString(value: String): String =
     when (val header = headers().lastHeader(value)) {
         null -> "".also { log.warn("Kafka header missing: $value") }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -48,6 +48,8 @@ smtp {
   storeProtocol = "${SMTP_STORE_PROTOCOL:-pop3}"
   pop3FactoryPort = "${SMTP_POP3_FACTORY_PORT:-3110}"
   pop3FactoryFallback = "false"
+  smtpRedirectAddress = "${SMTP_REDIRECT_ADDRESS:-}"
+  smtpFromAddress = "${SMTP_FROM_ADDRESS:-noreply@nav.no}"
 }
 
 database {


### PR DESCRIPTION
Introduced usage of environment variable `SMTP_REDIRECT_ADDRESS` which, if set, redirects all outgoing mails to the address given. This is very useful in ie our dev environment where we might not want to spam our collaborators with hundreds of duplicate mails.

Default behaviour, when nothing is set, is to send out mails to the addresses given by the _emailAddresses_  kafka header.