### PR TITLE
#235 Bug: Tom tekst i eventData fører til feil ved hendelsesbehandling

### DIFF
--- a/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
@@ -31,7 +31,7 @@ fun eventLoggingService(
             eventType,
             mimeMessage.contentID ?: "",
             mimeMessage.messageID ?: "",
-            ""
+            "{}"
         )
     }
 
@@ -43,7 +43,7 @@ fun eventLoggingService(
             eventType,
             payload.contentId,
             payload.referenceId.toString(),
-            ""
+            "{}"
         )
     }
 
@@ -55,7 +55,7 @@ fun eventLoggingService(
             eventType,
             "",
             messageId.toString(),
-            ""
+            "{}"
         )
     }
 


### PR DESCRIPTION
Oppgave: https://github.com/navikt/team-emottak-docs/issues/235