### PR TITLE
Oppretter transport fra session for lavere overhead ved forwarding

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -58,7 +58,7 @@ fun main() = SuspendApp {
             val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient, eventLoggingService)
             val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
             val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
-            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService) }
+            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService, config().smtp) }
             val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository, eventLoggingService, mailSender)
             val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -4,6 +4,7 @@ import arrow.continuations.SuspendApp
 import arrow.continuations.ktor.server
 import arrow.core.raise.result
 import arrow.fx.coroutines.ResourceScope
+import arrow.fx.coroutines.autoCloseable
 import arrow.fx.coroutines.resourceScope
 import arrow.resilience.Schedule
 import io.ktor.server.application.Application
@@ -57,7 +58,7 @@ fun main() = SuspendApp {
             val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient, eventLoggingService)
             val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
             val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
-            val mailSender = MailSender(deps.session, eventLoggingService)
+            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService) }
             val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository, eventLoggingService, mailSender)
             val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -51,9 +51,7 @@ class MailSender(
 
     @Synchronized
     private fun connectForwardingTransport() {
-        if (!forwardTransport.isConnected) {
-            forwardTransport.connect()
-        }
+        if (!forwardTransport.isConnected) forwardTransport.connect()
     }
 
     override fun close() {

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -27,6 +27,7 @@ import no.nav.emottak.util.addEbXMLMimeHeaders
 import no.nav.emottak.utils.kafka.model.EventType.ERROR_WHILE_SENDING_MESSAGE_VIA_SMTP
 import no.nav.emottak.utils.kafka.model.EventType.MESSAGE_SENT_VIA_SMTP
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import java.io.Closeable
 import java.security.Security
 import kotlin.uuid.Uuid
 
@@ -40,23 +41,31 @@ private const val ENCODING_BASE64 = "base64"
 class MailSender(
     private val session: Session,
     private val eventLoggingService: ScopedEventLoggingService
-) {
+) : Closeable {
     private val smtp = config().smtp
+    private val forwardTransport: Transport = session.getTransport("smtp")
 
     init {
         Security.addProvider(BouncyCastleProvider())
     }
 
+    @Synchronized
+    private fun connectForwardingTransport() {
+        if (!forwardTransport.isConnected) {
+            forwardTransport.connect()
+        }
+    }
+
+    override fun close() {
+        if (forwardTransport.isConnected) forwardTransport.close()
+    }
+
     suspend fun rawForward(mimeMessage: MimeMessage, address: InternetAddress = InternetAddress(config().smtp.smtpT1EmottakAddress)) =
         withContext(Dispatchers.IO) {
             catch({
-                Transport
-                    .send(
-                        mimeMessage,
-                        arrayOf(address)
-                    ).also {
-                        log.info("Message forwarded to ${config().smtp.smtpT1EmottakAddress}")
-                    }
+                connectForwardingTransport()
+                forwardTransport.sendMessage(mimeMessage, arrayOf(address))
+                log.info("Message forwarded to ${config().smtp.smtpT1EmottakAddress}")
             }) { error: MessagingException ->
                 log.error("Failed to forward message: ${error.localizedMessage}", error)
             }

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -15,7 +15,7 @@ import jakarta.mail.internet.MimeMultipart
 import jakarta.mail.util.ByteArrayDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import no.nav.emottak.config
+import no.nav.emottak.configuration.Smtp
 import no.nav.emottak.log
 import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MessageType
@@ -41,9 +41,9 @@ private const val ENCODING_BASE64 = "base64"
 
 class MailSender(
     private val session: Session,
-    private val eventLoggingService: ScopedEventLoggingService
+    private val eventLoggingService: ScopedEventLoggingService,
+    private val smtp: Smtp
 ) : Closeable {
-    private val smtp = config().smtp
     private val transport: Transport = session.getTransport("smtp")
 
     init {
@@ -60,11 +60,11 @@ class MailSender(
         if (transport.isConnected) transport.close()
     }
 
-    suspend fun rawForward(mimeMessage: MimeMessage, address: InternetAddress = InternetAddress(config().smtp.smtpT1EmottakAddress)) =
+    suspend fun rawForward(mimeMessage: MimeMessage, address: InternetAddress = InternetAddress(smtp.smtpT1EmottakAddress)) =
         withContext(Dispatchers.IO) {
             catch({
                 sendSynchronized(mimeMessage, arrayOf(address))
-                log.info("Message forwarded to ${config().smtp.smtpT1EmottakAddress}")
+                log.info("Message forwarded to ${smtp.smtpT1EmottakAddress}")
             }) { error: MessagingException ->
                 log.error("Failed to forward message: ${error.localizedMessage}", error)
             }

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -64,7 +64,7 @@ class MailSender(
         withContext(Dispatchers.IO) {
             catch({
                 sendSynchronized(mimeMessage, arrayOf(address))
-                log.info("Message forwarded to ${smtp.smtpT1EmottakAddress}")
+                log.info("Message forwarded to $address")
             }) { error: MessagingException ->
                 log.error("Failed to forward message: ${error.localizedMessage}", error)
             }

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.smtp
 
 import arrow.core.raise.catch
 import jakarta.activation.DataHandler
+import jakarta.mail.Address
 import jakarta.mail.Message.RecipientType.TO
 import jakarta.mail.MessagingException
 import jakarta.mail.Session
@@ -43,26 +44,26 @@ class MailSender(
     private val eventLoggingService: ScopedEventLoggingService
 ) : Closeable {
     private val smtp = config().smtp
-    private val forwardTransport: Transport = session.getTransport("smtp")
+    private val transport: Transport = session.getTransport("smtp")
 
     init {
         Security.addProvider(BouncyCastleProvider())
     }
 
     @Synchronized
-    private fun connectForwardingTransport() {
-        if (!forwardTransport.isConnected) forwardTransport.connect()
+    private fun sendSynchronized(message: MimeMessage, addresses: Array<out Address>) {
+        if (!transport.isConnected) transport.connect()
+        transport.sendMessage(message, addresses)
     }
 
     override fun close() {
-        if (forwardTransport.isConnected) forwardTransport.close()
+        if (transport.isConnected) transport.close()
     }
 
     suspend fun rawForward(mimeMessage: MimeMessage, address: InternetAddress = InternetAddress(config().smtp.smtpT1EmottakAddress)) =
         withContext(Dispatchers.IO) {
             catch({
-                connectForwardingTransport()
-                forwardTransport.sendMessage(mimeMessage, arrayOf(address))
+                sendSynchronized(mimeMessage, arrayOf(address))
                 log.info("Message forwarded to ${config().smtp.smtpT1EmottakAddress}")
             }) { error: MessagingException ->
                 log.error("Failed to forward message: ${error.localizedMessage}", error)
@@ -84,7 +85,7 @@ class MailSender(
     private suspend fun sendMessage(wrapper: MimeMessageWrapper, messageType: MessageType) =
         withContext(Dispatchers.IO) {
             catch({
-                Transport.send(wrapper.mimeMessage)
+                sendSynchronized(wrapper.mimeMessage, wrapper.mimeMessage.allRecipients)
                 eventLoggingService.registerEvent(
                     MESSAGE_SENT_VIA_SMTP,
                     wrapper.mimeMessage,
@@ -105,7 +106,7 @@ class MailSender(
             MimeMessage(session).apply {
                 addEbXMLMimeHeaders()
                 setFrom(getSender(metadata))
-                addRecipients(TO, getRecipients(metadata))
+                setRecipients(TO, getRecipients(metadata))
                 subject = metadata.subject
                 setDataHandler(
                     DataHandler(
@@ -122,7 +123,7 @@ class MailSender(
             MimeMessage(session).apply {
                 addEbXMLMimeHeaders()
                 setFrom(getSender(metadata))
-                addRecipients(TO, getRecipients(metadata))
+                setRecipients(TO, getRecipients(metadata))
                 subject = metadata.subject
                 val mainContentId = Uuid.random().toString()
                 val mimeMultipart = MimeMultipart("related").apply {

--- a/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
@@ -53,7 +53,7 @@ class MailReaderSpec : StringSpec({
 
             greenMail.receivedMessages.size shouldBe 3
 
-            val mailSender = MailSender(session, fakeEventLoggingService())
+            val mailSender = MailSender(session, fakeEventLoggingService(), config.smtp)
 
             mailSender.rawForward(greenMail.receivedMessages[0])
 

--- a/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
@@ -26,7 +26,7 @@ class MailSenderSpec : StringSpec({
             start()
             setUser(config.smtp.username.value, config.smtp.username.value, config.smtp.password.value)
         }
-        mailSender = MailSender(session, fakeEventLoggingService())
+        mailSender = MailSender(session, fakeEventLoggingService(), config.smtp)
     }
 
     afterEach {


### PR DESCRIPTION
Forwarding og sending bruker cirka 4 sekunder per melding. Det betyr at det tar veldig lang tid å forwarde mange meldinger.

Gjenbruker session transport object slik at den ikke må opprette og lukke kobling for hver eneste melding. Så lenge sesjonen er åpen, går tiden brukt på videresending fra ~4000ms til ~5ms. 

<img width="690" height="357" alt="image" src="https://github.com/user-attachments/assets/b75c7dc7-be85-46d0-abc4-3c210d9dbe50" />

