### PR TITLE
Refaktorer flyten som merker mimemessage som slettet

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -58,7 +58,7 @@ fun main() = SuspendApp {
             val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
             val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
             val mailSender = MailSender(deps.session, eventLoggingService)
-            val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository, eventLoggingService, mailSender)
+            val mailProcessor = MailProcessor(deps.store, mailPublisher, payloadRepository, eventLoggingService, mailSender, config().mail)
             val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 
             val server = config().server

--- a/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
@@ -3,14 +3,11 @@ package no.nav.emottak.processor
 import arrow.autoCloseScope
 import arrow.core.raise.fold
 import jakarta.mail.Store
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers
@@ -27,7 +24,6 @@ import no.nav.emottak.util.ForwardingSystem
 import no.nav.emottak.util.ScopedEventLoggingService
 import no.nav.emottak.util.toPayloadMessage
 import no.nav.emottak.util.toSignalMessage
-import org.apache.kafka.clients.producer.RecordMetadata
 import kotlin.math.min
 
 class MailProcessor(
@@ -37,32 +33,40 @@ class MailProcessor(
     private val eventLoggingService: ScopedEventLoggingService,
     private val mailSender: MailSender
 ) {
-    fun processMessages(scope: CoroutineScope) =
-        readMessages()
-            .onEach(::processMessage)
-            .flowOn(Dispatchers.IO)
-            .launchIn(scope)
-
-    private fun readMessages(): Flow<EmailMsg> = autoCloseScope {
-        val mailReader = install(
-            MailReader(
-                config().mail,
-                store,
-                config().mail.inboxExpunge,
-                eventLoggingService
+    fun processMessages(scope: CoroutineScope): Job = scope.launch(Dispatchers.IO) {
+        autoCloseScope {
+            val mailReader = install(
+                MailReader(
+                    config().mail,
+                    store,
+                    config().mail.inboxExpunge,
+                    eventLoggingService
+                )
             )
-        )
-        val messageCount = mailReader.count()
-        val batchSize = min(config().mail.inboxBatchReadLimit, messageCount)
+            val messageCount = mailReader.count()
+            val batchSize = min(config().mail.inboxBatchReadLimit, messageCount)
 
-        if (messageCount > 0) {
-            log.info("Starting to read $batchSize of $messageCount messages from inbox")
-            mailReader.readMailBatches(batchSize)
-                .asFlow()
-                .also { log.info("Finished reading $batchSize of $messageCount messages from inbox") }
-        } else {
-            log.info("No messages found in inbox")
-            emptyFlow()
+            if (messageCount > 0) {
+                log.info("Starting to read $batchSize of $messageCount messages from inbox")
+                mailReader.readMailBatches(batchSize).forEach { emailMsg ->
+                    try {
+                        processMessage(emailMsg)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.error("Failed to process message, leaving in inbox for retry", e)
+                        return@forEach
+                    }
+                    try {
+                        mailReader.markDeleted(emailMsg.originalMimeMessage)
+                    } catch (e: Exception) {
+                        log.warn("Message processed successfully but failed to mark as deleted", e)
+                    }
+                }
+                log.info("Finished processing $batchSize of $messageCount messages from inbox")
+            } else {
+                log.info("No messages found in inbox")
+            }
         }
     }
 
@@ -104,10 +108,11 @@ class MailProcessor(
             fold(
                 { insert(payloadMessage.payloads) },
                 { log.error("Could not insert payloads: ${payloadMessage.payloads.map { it }}") }
-            ) { mailPublisher.publishPayloadMessage(payloadMessage, senderAddress) }
+            ) { mailPublisher.publishPayloadMessage(payloadMessage, senderAddress).getOrThrow() }
         }
     }
 
-    private suspend fun publishSignalMessage(signalMessage: SignalMessage, senderAddress: String): Result<RecordMetadata> =
-        mailPublisher.publishSignalMessage(signalMessage, senderAddress)
+    private suspend fun publishSignalMessage(signalMessage: SignalMessage, senderAddress: String) {
+        mailPublisher.publishSignalMessage(signalMessage, senderAddress).getOrThrow()
+    }
 }

--- a/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers
-import no.nav.emottak.config
+import no.nav.emottak.configuration.Mail
 import no.nav.emottak.log
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
@@ -31,20 +31,21 @@ class MailProcessor(
     private val mailPublisher: MailPublisher,
     private val payloadRepository: PayloadRepository,
     private val eventLoggingService: ScopedEventLoggingService,
-    private val mailSender: MailSender
+    private val mailSender: MailSender,
+    private val mail: Mail
 ) {
     fun processMessages(scope: CoroutineScope): Job = scope.launch(Dispatchers.IO) {
         autoCloseScope {
             val mailReader = install(
                 MailReader(
-                    config().mail,
+                    mail,
                     store,
-                    config().mail.inboxExpunge,
+                    mail.inboxExpunge,
                     eventLoggingService
                 )
             )
             val messageCount = mailReader.count()
-            val batchSize = min(config().mail.inboxBatchReadLimit, messageCount)
+            val batchSize = min(mail.inboxBatchReadLimit, messageCount)
 
             if (messageCount > 0) {
                 log.info("Starting to read $batchSize of $messageCount messages from inbox")

--- a/src/main/kotlin/no/nav/emottak/smtp/MailReader.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailReader.kt
@@ -96,17 +96,16 @@ class MailReader(
 
     private fun expunge(): Boolean = (expunge || count() > mail.inboxLimit)
 
+    fun markDeleted(mimeMessage: MimeMessage) {
+        mimeMessage.setFlag(DELETED, expunge())
+    }
+
     private fun processMimeMessage(wrapper: MimeMessageWrapper) {
         when (wrapper.mimeMessage.content) {
             is MimeMultipart -> logMimeMultipartMessage(wrapper.mimeMessage)
             else -> logMimeMessage(wrapper.mimeMessage)
         }
         log.debug("From: <{}> Subject: <{}>", wrapper.mimeMessage.from[0], wrapper.mimeMessage.subject)
-        setDeletedFlagOnMimeMessage(wrapper.mimeMessage)
-    }
-
-    private fun setDeletedFlagOnMimeMessage(mimeMessage: MimeMessage) {
-        mimeMessage.setFlag(DELETED, expunge())
     }
 
     private fun logMimeMessage(mimeMessage: MimeMessage) {

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -59,6 +59,7 @@ class MailSender(
                     }
             }) { error: MessagingException ->
                 log.error("Failed to forward message: ${error.localizedMessage}", error)
+                throw error
             }
         }
 

--- a/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
@@ -105,7 +105,9 @@ class MailReaderSpec : StringSpec({
             val inboxLimit100 = config.mail.copy(inboxLimit = 100)
             val reader = MailReader(inboxLimit100, store, false, eventLoggingService)
 
-            reader.readMailBatches(3).size shouldBe 3
+            val batch1 = reader.readMailBatches(3)
+            batch1.size shouldBe 3
+            batch1.forEach { reader.markDeleted(it.originalMimeMessage) }
             reader.readMailBatches(3).size shouldBe 0
             reader.close()
 
@@ -114,7 +116,9 @@ class MailReaderSpec : StringSpec({
             val inboxLimitNegative1 = config.mail.copy(inboxLimit = -1)
             val reader2 = MailReader(inboxLimitNegative1, store, false, eventLoggingService)
 
-            reader2.readMailBatches(3).size shouldBe 3
+            val batch2 = reader2.readMailBatches(3)
+            batch2.size shouldBe 3
+            batch2.forEach { reader2.markDeleted(it.originalMimeMessage) }
             reader2.readMailBatches(3).size shouldBe 0
             reader2.close()
 
@@ -172,20 +176,39 @@ class MailReaderSpec : StringSpec({
 
             val mailConfig = config.mail
 
-            val reader = MailReader(mailConfig, store, true, eventLoggingService)
-            reader.count() shouldBe 3
-            reader.readMailBatches(1).size shouldBe 1
-            reader.close()
+            // Read 1 email per batch. Should be one less email per batch retrieval
+            // Inbox starts with 3 messages
+            with(MailReader(mailConfig, store, true, eventLoggingService)) {
+                this.count() shouldBe 3
+                val batch1 = this.readMailBatches(1)
+                batch1.size shouldBe 1
+                batch1.forEach { this.markDeleted(it.originalMimeMessage) }
+                this.close()
+            }
 
-            val reader2 = MailReader(mailConfig, store, true, eventLoggingService)
-            reader2.count() shouldBe 2
-            reader2.readMailBatches(1).size shouldBe 1
-            reader2.close()
+            with(MailReader(mailConfig, store, true, eventLoggingService)) {
+                this.count() shouldBe 2
+                val batch2 = this.readMailBatches(1)
+                batch2.size shouldBe 1
+                batch2.forEach { this.markDeleted(it.originalMimeMessage) }
+                this.close()
+            }
 
-            val reader3 = MailReader(mailConfig, store, true, eventLoggingService)
-            reader3.count() shouldBe 1
-            reader3.readMailBatches(1).size shouldBe 1
-            reader3.close()
+            with(MailReader(mailConfig, store, true, eventLoggingService)) {
+                this.count() shouldBe 1
+                val batch3 = this.readMailBatches(1)
+                batch3.size shouldBe 1
+                batch3.forEach { this.markDeleted(it.originalMimeMessage) }
+                this.close()
+            }
+
+            with(MailReader(mailConfig, store, true, eventLoggingService)) {
+                this.count() shouldBe 0
+                val batch4 = this.readMailBatches(1)
+                batch4.size shouldBe 0
+                batch4.forEach { this.markDeleted(it.originalMimeMessage) }
+                this.close()
+            }
         }
     }
 })

--- a/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
@@ -211,4 +211,30 @@ class MailReaderSpec : StringSpec({
             }
         }
     }
+
+    "MailReader expunges only messages marked for deletion" {
+        resourceScope {
+            val store = store(config.smtp)
+            val eventLoggingService = fakeEventLoggingService()
+
+            val mailConfig = config.mail
+
+            val reader1 = MailReader(mailConfig, store, true, eventLoggingService)
+            reader1.count() shouldBe 3
+            val batch1 = reader1.readMailBatches(3)
+            batch1.size shouldBe 3
+            batch1[0].headers["Message-ID"] shouldBe "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>"
+            batch1[1].headers["Message-ID"] shouldBe "<20231121144547.5CB191829F67@a01drvl071.adeo.no>"
+            batch1[2].headers["Message-ID"] shouldBe "f3d09378-4f14-4ab9-abea-bd415606283f"
+            reader1.markDeleted(batch1[1].originalMimeMessage)
+            reader1.close()
+
+            val reader2 = MailReader(mailConfig, store, true, eventLoggingService)
+            reader2.count() shouldBe 2
+            val batch2 = reader2.readMailBatches(3)
+            batch2.size shouldBe 2
+            batch2[0].headers["Message-ID"] shouldBe "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>"
+            batch2[1].headers["Message-ID"] shouldBe "f3d09378-4f14-4ab9-abea-bd415606283f"
+        }
+    }
 })

--- a/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
@@ -216,25 +216,34 @@ class MailReaderSpec : StringSpec({
         resourceScope {
             val store = store(config.smtp)
             val eventLoggingService = fakeEventLoggingService()
-
             val mailConfig = config.mail
 
             val reader1 = MailReader(mailConfig, store, true, eventLoggingService)
             reader1.count() shouldBe 3
             val batch1 = reader1.readMailBatches(3)
             batch1.size shouldBe 3
-            batch1[0].headers["Message-ID"] shouldBe "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>"
-            batch1[1].headers["Message-ID"] shouldBe "<20231121144547.5CB191829F67@a01drvl071.adeo.no>"
-            batch1[2].headers["Message-ID"] shouldBe "f3d09378-4f14-4ab9-abea-bd415606283f"
-            reader1.markDeleted(batch1[1].originalMimeMessage)
+
+            val allMessageIds = batch1.map { it.headers["Message-ID"] }.toSet()
+            allMessageIds shouldBe setOf(
+                "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>",
+                "<20231121144547.5CB191829F67@a01drvl071.adeo.no>",
+                "f3d09378-4f14-4ab9-abea-bd415606283f"
+            )
+
+            val messageToDelete = batch1.first { it.headers["Message-ID"] == "<20231121144547.5CB191829F67@a01drvl071.adeo.no>" }
+            reader1.markDeleted(messageToDelete.originalMimeMessage)
             reader1.close()
 
             val reader2 = MailReader(mailConfig, store, true, eventLoggingService)
             reader2.count() shouldBe 2
             val batch2 = reader2.readMailBatches(3)
             batch2.size shouldBe 2
-            batch2[0].headers["Message-ID"] shouldBe "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>"
-            batch2[1].headers["Message-ID"] shouldBe "f3d09378-4f14-4ab9-abea-bd415606283f"
+
+            val remainingMessageIds = batch2.map { it.headers["Message-ID"] }.toSet()
+            remainingMessageIds shouldBe setOf(
+                "<f3da7fd6-5262-4383-9ed8-ec68936e8f55@link.visma.no>",
+                "f3d09378-4f14-4ab9-abea-bd415606283f"
+            )
         }
     }
 })

--- a/src/test/resources/mails/test@test.test/INBOX/EgenAndelForespoersel.eml
+++ b/src/test/resources/mails/test@test.test/INBOX/EgenAndelForespoersel.eml
@@ -16,7 +16,7 @@ To: mottak-qass@test-es.nav.no
 Subject: EgenandelForesporsel
 Date: Thu, 30 Nov 2023 13:15:29 +1
 X-Mailer: CommunicateSMTPClient
-Message-Id: f3d09378-4f14-4ab9-abea-bd415606283f
+Message-ID: f3d09378-4f14-4ab9-abea-bd415606283f
 MIME-Version: 1.0
 Content-Type: multipart/related;
 	type="text/xml";

--- a/src/test/resources/mails/test@test.test/INBOX/acknowledgment.eml
+++ b/src/test/resources/mails/test@test.test/INBOX/acknowledgment.eml
@@ -22,7 +22,7 @@ Date: Tue, 21 Nov 2023 14:45:47 +0000
 MIME-Version: 1.0
 Content-Type: text/xml; charset=utf-8
 Content-Transfer-Encoding: base64
-Message-Id: <20231121144547.5CB191829F67@a01drvl071.adeo.no>
+Message-ID: <20231121144547.5CB191829F67@a01drvl071.adeo.no>
 
 PFNPQVA6RW52ZWxvcGUgeG1sbnM6ZWI9Imh0dHA6Ly93d3cub2FzaXMtb3Blbi5vcmcvY29tbWl0
 dGVlcy9lYnhtbC1tc2cvc2NoZW1hL21zZy1oZWFkZXItMl8wLnhzZCIgeG1sbnM6eHNpPSJodHRw


### PR DESCRIPTION
https://github.com/navikt/team-emottak-docs/issues/316

Setter mimemessage deleted til true kun når meldingen er ferdig prosessert (lagt på kafka og/eller videresendt på epost). 