### PR TITLE
Routing basert på CPA istedenfor e-post

### DIFF
--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -187,5 +187,5 @@ data class AzureAuth(
 data class EbmsFilter(
     val typesToEbms: List<String>,
     val typesToBoth: List<String>,
-    val cpa: Set<String>
+    val cpaId: Set<String>
 )

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -187,6 +187,5 @@ data class AzureAuth(
 data class EbmsFilter(
     val typesToEbms: List<String>,
     val typesToBoth: List<String>,
-    val senderAddresses: Set<String>,
     val cpa: Set<String>
 )

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -187,5 +187,6 @@ data class AzureAuth(
 data class EbmsFilter(
     val typesToEbms: List<String>,
     val typesToBoth: List<String>,
-    val senderAddresses: Set<String>
+    val senderAddresses: Set<String>,
+    val cpa: Set<String>
 )

--- a/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
+++ b/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
@@ -16,6 +16,7 @@ import javax.xml.xpath.XPathFactory
 
 private val typesToEbms = config().ebmsFilter.typesToEbms
 private val typesToBoth = config().ebmsFilter.typesToBoth
+private val cpaIds = config().ebmsFilter.cpaId
 
 fun EmailMsg.filterMessageForwarding(): ForwardableMimeMessage {
     return when (val forwardingSystem = this.filterMimeMessage()) {
@@ -56,7 +57,7 @@ fun EmailMsg.filterMimeMessage(): ForwardingSystem {
     }
 }
 
-private fun isAcceptedCpaId(cpaId: String) = config().ebmsFilter.cpaId.any { it.equals(cpaId, ignoreCase = true) }
+private fun isAcceptedCpaId(cpaId: String) = cpaIds.any { it.equals(cpaId, ignoreCase = true) }
 
 private fun ByteArray.toXmlDocument(): Document? {
     return try {

--- a/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
+++ b/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
@@ -26,9 +26,9 @@ fun EmailMsg.filterMessageForwarding(): ForwardableMimeMessage {
 }
 
 fun EmailMsg.filterMimeMessage(): ForwardingSystem {
-    val ebxmlDocument = getEnvelope().toXmlDocument() ?: return ForwardingSystem.EMOTTAK
-    val envelopeServiceName = ebxmlDocument.getEbxmlServiceName()
-    val envelopeCpaId = ebxmlDocument.getEbxmlCpaId()
+    val ebxmlDocument = getEnvelope().toXmlDocument()
+    val envelopeServiceName = ebxmlDocument?.getEbxmlServiceName() ?: "UnparsableService"
+    val envelopeCpaId = ebxmlDocument?.getEbxmlCpaId() ?: "UnparsableCpaId"
 
     return if (isAcceptedCpaId(envelopeCpaId)) {
         if (typesToBoth.contains(envelopeServiceName)) {
@@ -56,7 +56,7 @@ fun EmailMsg.filterMimeMessage(): ForwardingSystem {
     }
 }
 
-private fun isAcceptedCpaId(cpaId: String) = config().ebmsFilter.cpa.any { it.equals(cpaId, ignoreCase = true) }
+private fun isAcceptedCpaId(cpaId: String) = config().ebmsFilter.cpaId.any { it.equals(cpaId, ignoreCase = true) }
 
 private fun ByteArray.toXmlDocument(): Document? {
     return try {

--- a/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
+++ b/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
@@ -19,14 +19,14 @@ private val typesToBoth = config().ebmsFilter.typesToBoth
 private val cpaIds = config().ebmsFilter.cpaId
 
 fun EmailMsg.filterMessageForwarding(): ForwardableMimeMessage {
-    return when (val forwardingSystem = this.filterMimeMessage()) {
+    return when (val forwardingSystem = this.getForwardingSystem()) {
         ForwardingSystem.EBMS -> ForwardableMimeMessage(forwardingSystem, null)
         ForwardingSystem.EMOTTAK -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
         ForwardingSystem.BOTH -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
     }
 }
 
-fun EmailMsg.filterMimeMessage(): ForwardingSystem {
+fun EmailMsg.getForwardingSystem(): ForwardingSystem {
     val ebxmlDocument = getEnvelope().toXmlDocument()
     val envelopeServiceName = ebxmlDocument?.getEbxmlServiceName() ?: "UnparsableService"
     val envelopeCpaId = ebxmlDocument?.getEbxmlCpaId() ?: "UnparsableCpaId"

--- a/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
+++ b/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
@@ -18,39 +18,45 @@ private val typesToEbms = config().ebmsFilter.typesToEbms
 private val typesToBoth = config().ebmsFilter.typesToBoth
 
 fun EmailMsg.filterMessageForwarding(): ForwardableMimeMessage {
-    val (forwardingSystem, serviceName) = this.filterMimeMessage()
-    val marker: LogstashMarker = Markers.appendEntries(
-        mapOf(
-            "requestId" to this.requestId.toString(),
-            "smtpSender" to this.senderAddress,
-            "smtpSubject" to (this.headers["Subject"] ?: "-"),
-            "service" to serviceName,
-            "forwardingSystem" to forwardingSystem,
-            "sourceSystem" to (this.headers["X-Mailer"] ?: "-")
-        )
-    )
-    log.info(marker, "Message forwarding system identified")
-    return when (forwardingSystem) {
+    return when (val forwardingSystem = this.filterMimeMessage()) {
         ForwardingSystem.EBMS -> ForwardableMimeMessage(forwardingSystem, null)
         ForwardingSystem.EMOTTAK -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
         ForwardingSystem.BOTH -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
     }
 }
 
-fun EmailMsg.filterMimeMessage(): Pair<ForwardingSystem, String> {
-    val envelopeServiceName = getEnvelope().toXmlDocument()?.getEbxmlServiceName() ?: "Unparseable"
-    if (isFromAcceptedAddress(senderAddress)) {
+fun EmailMsg.filterMimeMessage(): ForwardingSystem {
+    val ebxmlDocument = getEnvelope().toXmlDocument() ?: return ForwardingSystem.EMOTTAK
+    val envelopeServiceName = ebxmlDocument.getEbxmlServiceName()
+    val envelopeCpaId = ebxmlDocument.getEbxmlCpaId()
+
+    return if (isAcceptedCpaId(envelopeCpaId)) {
         if (typesToBoth.contains(envelopeServiceName)) {
-            return ForwardingSystem.BOTH to envelopeServiceName
+            ForwardingSystem.BOTH
+        } else if (typesToEbms.contains(envelopeServiceName)) {
+            ForwardingSystem.EBMS
+        } else {
+            ForwardingSystem.EMOTTAK
         }
-        if (typesToEbms.contains(envelopeServiceName)) {
-            return ForwardingSystem.EBMS to envelopeServiceName
-        }
+    } else {
+        ForwardingSystem.EMOTTAK
+    }.also {
+        val marker: LogstashMarker = Markers.appendEntries(
+            mapOf(
+                "requestId" to this.requestId.toString(),
+                "smtpSender" to this.senderAddress,
+                "smtpSubject" to (this.headers["Subject"] ?: "-"),
+                "service" to envelopeServiceName,
+                "cpaId" to envelopeCpaId,
+                "forwardingSystem" to it,
+                "sourceSystem" to (this.headers["X-Mailer"] ?: "-")
+            )
+        )
+        log.info(marker, "Message forwarding system identified")
     }
-    return ForwardingSystem.EMOTTAK to envelopeServiceName
 }
 
-private fun isFromAcceptedAddress(from: String) = config().ebmsFilter.senderAddresses.any { it.equals(from, ignoreCase = true) }
+private fun isAcceptedCpaId(cpaId: String) = config().ebmsFilter.cpa.any { it.equals(cpaId, ignoreCase = true) }
 
 private fun ByteArray.toXmlDocument(): Document? {
     return try {
@@ -67,7 +73,10 @@ private fun ByteArray.toXmlDocument(): Document? {
     }
 }
 
-private fun Document.getEbxmlServiceName(): String {
+private fun Document.getEbxmlServiceName(): String = this.getXmlElementValue("Service")
+private fun Document.getEbxmlCpaId(): String = this.getXmlElementValue("CPAId")
+
+private fun Document.getXmlElementValue(elementName: String): String {
     return try {
         val nsUri = this.documentElement.namespaceURI
         val xPath = XPathFactory.newInstance().newXPath()
@@ -78,7 +87,7 @@ private fun Document.getEbxmlServiceName(): String {
                 override fun getPrefixes(namespaceURI: String?): MutableIterator<String> = mutableListOf<String>().iterator()
             }
         }
-        val localNameExpr = "//*[local-name()='Service']"
+        val localNameExpr = "//*[local-name()='$elementName']"
         val nodeList = xPath.evaluate(localNameExpr, this, XPathConstants.NODESET) as NodeList
         return if (nodeList.length == 1) {
             nodeList.item(0).textContent
@@ -86,8 +95,8 @@ private fun Document.getEbxmlServiceName(): String {
             "Unknown"
         }
     } catch (e: Exception) {
-        log.warn("Failed to check XML for element 'Service': ${e.message}")
-        "ExceptionThrown"
+        log.warn("Failed to check XML for element '$elementName': ${e.message}")
+        e::class.simpleName ?: "UnknownError"
     }
 }
 

--- a/src/main/resources/filter-dev.conf
+++ b/src/main/resources/filter-dev.conf
@@ -15,4 +15,9 @@ ebmsFilter {
     "no-reply@nav.no",
     "nyebmsbcc@test-es.nav.no"
   ]
+  cpa = [
+    "nav:qass:36666",
+    "nav:qass:30500",
+    "nav:qass:34961"
+  ]
 }

--- a/src/main/resources/filter-dev.conf
+++ b/src/main/resources/filter-dev.conf
@@ -6,18 +6,13 @@ ebmsFilter {
     "urn:oasis:names:tc:ebxml-msg:service",
     "Trekkopplysning"
   ]
-  senderAddresses = [
-    // TEST
-    "cfc_mail1@fastmail.com",
-    "aidn.test.dev@testedi.nhn.no",
-    "aidn.test.demo@testedi.nhn.no",
-    "test_aidn_voss@testedi.nhn.no",
-    "no-reply@nav.no",
-    "nyebmsbcc@test-es.nav.no"
-  ]
   cpa = [
     "nav:qass:36666",
     "nav:qass:30500",
-    "nav:qass:34961"
+    "nav:qass:34961",
+    "nav:qass:36181",
+    "nav:qass:36221",
+    "nav:qass:37969",
+    "nav:qass:36584"
   ]
 }

--- a/src/main/resources/filter-dev.conf
+++ b/src/main/resources/filter-dev.conf
@@ -6,7 +6,7 @@ ebmsFilter {
     "urn:oasis:names:tc:ebxml-msg:service",
     "Trekkopplysning"
   ]
-  cpa = [
+  cpaId = [
     "nav:qass:36666",
     "nav:qass:30500",
     "nav:qass:34961",

--- a/src/main/resources/filter-prod.conf
+++ b/src/main/resources/filter-prod.conf
@@ -5,7 +5,7 @@ ebmsFilter {
   typesToBoth = [
     "urn:oasis:names:tc:ebxml-msg:service",
   ]
-  cpa = [
+  cpaId = [
     "nav:119670",
     "nav:115510",
     "nav:63242",

--- a/src/main/resources/filter-prod.conf
+++ b/src/main/resources/filter-prod.conf
@@ -5,25 +5,21 @@ ebmsFilter {
   typesToBoth = [
     "urn:oasis:names:tc:ebxml-msg:service",
   ]
-  senderAddresses = [
-    // PROD
-    "aidn.eidfjord@edi.nhn.no",
-    "aidn.ullensvang@edi.nhn.no",
-    "aidn.vestvagoy@edi.nhn.no",
-    "aidn.vagan@edi.nhn.no",
-    "aidn.hole@edi.nhn.no",
-    "aidn.lodingenkommune@edi.nhn.no",
-    "aidn.boe@edi.nhn.no",
-    "aidn.andoy@edi.nhn.no",
-    "aidn.flakstad@edi.nhn.no",
-    "aidn.oksnes@edi.nhn.no",
-    "aidn.hadsel@edi.nhn.no",
-    "aidn.ulvikkommune@edi.nhn.no",
-    "sykepleietjeneste.aidn.sor@edi.nhn.no",
-    "aidn.moskenes@edi.nhn.no",
-    "aidn.varoy@edi.nhn.no"
-  ]
   cpa = [
-    "nav:12345"
+    "nav:119670",
+    "nav:115510",
+    "nav:63242",
+    "nav:119530",
+    "nav:115227",
+    "nav:119189",
+    "nav:63007",
+    "nav:119191",
+    "nav:119567",
+    "nav:21723",
+    "nav:117252",
+    "nav:119671",
+    "nav:114608",
+    "nav:119528",
+    "nav:119568"
   ]
 }

--- a/src/main/resources/filter-prod.conf
+++ b/src/main/resources/filter-prod.conf
@@ -22,4 +22,7 @@ ebmsFilter {
     "sykepleietjeneste.aidn.sor@edi.nhn.no",
     "aidn.moskenes@edi.nhn.no"
   ]
+  cpa = [
+    "nav:12345"
+  ]
 }

--- a/src/test/kotlin/no/nav/emottak/ConfiguratorSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/ConfiguratorSpec.kt
@@ -99,7 +99,7 @@ class ConfiguratorSpec : StringSpec({
     }
 
     "dev filter senderCPAs are populated" {
-        val senderCPAs = config().ebmsFilter.cpa
+        val senderCPAs = config().ebmsFilter.cpaId
         senderCPAs.shouldNotBeEmpty()
         senderCPAs shouldContain "nav:qass:36666"
     }
@@ -117,8 +117,8 @@ class ConfiguratorSpec : StringSpec({
         val filter = prodConfig.ebmsFilter
         filter.typesToEbms shouldContain "Inntektsforesporsel"
         filter.typesToBoth shouldContain "urn:oasis:names:tc:ebxml-msg:service"
-        filter.cpa.shouldNotBeEmpty()
-        filter.cpa shouldNotContain "nav:qass:36666"
+        filter.cpaId.shouldNotBeEmpty()
+        filter.cpaId shouldNotContain "nav:qass:36666"
     }
 
     "prod filter senderCPAs differ from dev filter" {
@@ -131,8 +131,8 @@ class ConfiguratorSpec : StringSpec({
             .build()
             .loadConfigOrThrow<Config>()
 
-        val devCpa = config().ebmsFilter.cpa
-        val prodCpa = prodConfig.ebmsFilter.cpa
+        val devCpa = config().ebmsFilter.cpaId
+        val prodCpa = prodConfig.ebmsFilter.cpaId
         devCpa shouldContain "nav:qass:36666"
         prodCpa shouldNotContain "nav:qass:36666"
         (devCpa intersect prodCpa).isEmpty() shouldBe true

--- a/src/test/kotlin/no/nav/emottak/ConfiguratorSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/ConfiguratorSpec.kt
@@ -98,10 +98,10 @@ class ConfiguratorSpec : StringSpec({
         typesToBoth shouldContain "Trekkopplysning"
     }
 
-    "dev filter senderAddresses are populated" {
-        val senderAddresses = config().ebmsFilter.senderAddresses
-        senderAddresses.shouldNotBeEmpty()
-        senderAddresses shouldContain "nyebmsbcc@test-es.nav.no"
+    "dev filter senderCPAs are populated" {
+        val senderCPAs = config().ebmsFilter.cpa
+        senderCPAs.shouldNotBeEmpty()
+        senderCPAs shouldContain "nav:qass:36666"
     }
 
     "prod filter can be loaded directly and has expected values" {
@@ -117,11 +117,11 @@ class ConfiguratorSpec : StringSpec({
         val filter = prodConfig.ebmsFilter
         filter.typesToEbms shouldContain "Inntektsforesporsel"
         filter.typesToBoth shouldContain "urn:oasis:names:tc:ebxml-msg:service"
-        filter.senderAddresses.shouldNotBeEmpty()
-        filter.senderAddresses shouldNotContain "nyebmsbcc@test-es.nav.no"
+        filter.cpa.shouldNotBeEmpty()
+        filter.cpa shouldNotContain "nav:qass:36666"
     }
 
-    "prod filter senderAddresses differ from dev filter" {
+    "prod filter senderCPAs differ from dev filter" {
         @OptIn(ExperimentalHoplite::class)
         val prodConfig = ConfigLoader.builder()
             .addResourceSource("/kafka_common.conf")
@@ -131,10 +131,10 @@ class ConfiguratorSpec : StringSpec({
             .build()
             .loadConfigOrThrow<Config>()
 
-        val devSenders = config().ebmsFilter.senderAddresses
-        val prodSenders = prodConfig.ebmsFilter.senderAddresses
-        devSenders shouldContain "nyebmsbcc@test-es.nav.no"
-        prodSenders shouldNotContain "nyebmsbcc@test-es.nav.no"
-        (devSenders intersect prodSenders).isEmpty() shouldBe true
+        val devCpa = config().ebmsFilter.cpa
+        val prodCpa = prodConfig.ebmsFilter.cpa
+        devCpa shouldContain "nav:qass:36666"
+        prodCpa shouldNotContain "nav:qass:36666"
+        (devCpa intersect prodCpa).isEmpty() shouldBe true
     }
 })

--- a/src/test/kotlin/no/nav/emottak/util/EmailMsgFilterSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/util/EmailMsgFilterSpec.kt
@@ -10,12 +10,12 @@ import no.nav.emottak.smtp.MimeMessageWrapper
 import kotlin.uuid.Uuid
 
 private const val PAYLOAD_MESSAGE = "testmail/inntektsforesporsel.eml"
-private const val PAYLOAD_MESSAGE_INVALID_FROM = "testmail/inntektsforesporsel_invalid_from.eml"
+private const val PAYLOAD_MESSAGE_INVALID_CPAID = "testmail/inntektsforesporsel_invalid_cpaid.eml"
 private const val PAYLOAD_MESSAGE_INVALID_SERVICE = "testmail/egenandelforesporsel.eml"
 private const val SIGNAL_MESSAGE = "testmail/acknowledgment.eml"
-private const val SIGNAL_MESSAGE_NO_FROM = "testmail/acknowledgment_no_from.eml"
 private const val NOT_EBXML_MESSAGE = "testmail/not_ebxml.eml"
 private const val EBXML_NO_SERVICE = "testmail/ebxml_no_service.eml"
+private const val EBXML_NO_CPAID = "testmail/ebxml_no_cpaid.eml"
 
 class EmailMsgFilterSpec : StringSpec({
     val config = config()
@@ -27,46 +27,39 @@ class EmailMsgFilterSpec : StringSpec({
             requestId = Uuid.random()
         ).mapEmailMsg()
 
-    "Returns BOTH when From is valid and signal message" {
-        val (forwardingSystem, serviceName) = SIGNAL_MESSAGE.emlToEmailMsg().filterMimeMessage()
+    "Returns BOTH when CPAId is valid and signal message" {
+        val forwardingSystem = SIGNAL_MESSAGE.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.BOTH
-        serviceName shouldBe "urn:oasis:names:tc:ebxml-msg:service"
     }
 
-    "Returns EBMS when From is valid and accepted type" {
-        val (forwardingSystem, serviceName) = PAYLOAD_MESSAGE.emlToEmailMsg().filterMimeMessage()
+    "Returns EBMS when CPAId is valid and accepted type" {
+        val forwardingSystem = PAYLOAD_MESSAGE.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EBMS
-        serviceName shouldBe "Inntektsforesporsel"
     }
 
-    "Returns EMOTTAK when From is missing" {
-        val (forwardingSystem, serviceName) = SIGNAL_MESSAGE_NO_FROM.emlToEmailMsg().filterMimeMessage()
+    "Returns EMOTTAK when CPAId is missing" {
+        val forwardingSystem = EBXML_NO_CPAID.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
-        serviceName shouldBe "urn:oasis:names:tc:ebxml-msg:service"
     }
 
-    "Returns EMOTTAK when From is not accepted" {
-        val (forwardingSystem, serviceName) = PAYLOAD_MESSAGE_INVALID_FROM.emlToEmailMsg().filterMimeMessage()
+    "Returns EMOTTAK when CPAId is not accepted" {
+        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_CPAID.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
-        serviceName shouldBe "Inntektsforesporsel"
     }
 
     "Returns EMOTTAK when Service Type is not accepted" {
-        val (forwardingSystem, serviceName) = PAYLOAD_MESSAGE_INVALID_SERVICE.emlToEmailMsg().filterMimeMessage()
+        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_SERVICE.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
-        serviceName shouldBe "HarBorgerFrikortMengde"
     }
 
     "Returns EMOTTAK when Service Type is not found" {
-        val (forwardingSystem, serviceName) = EBXML_NO_SERVICE.emlToEmailMsg().filterMimeMessage()
+        val forwardingSystem = EBXML_NO_SERVICE.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
-        serviceName shouldBe "Unknown"
     }
 
     "Returns EMOTTAK when document is unparsable" {
-        val (forwardingSystem, serviceName) = NOT_EBXML_MESSAGE.emlToEmailMsg().filterMimeMessage()
+        val forwardingSystem = NOT_EBXML_MESSAGE.emlToEmailMsg().filterMimeMessage()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
-        serviceName shouldBe "Unparseable"
     }
 
     "extracts email address only when From contains angle brackets" {

--- a/src/test/kotlin/no/nav/emottak/util/EmailMsgFilterSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/util/EmailMsgFilterSpec.kt
@@ -27,38 +27,38 @@ class EmailMsgFilterSpec : StringSpec({
             requestId = Uuid.random()
         ).mapEmailMsg()
 
-    "Returns BOTH when CPAId is valid and signal message" {
-        val forwardingSystem = SIGNAL_MESSAGE.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns BOTH when CPAId is valid and signal message" {
+        val forwardingSystem = SIGNAL_MESSAGE.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.BOTH
     }
 
-    "Returns EBMS when CPAId is valid and accepted type" {
-        val forwardingSystem = PAYLOAD_MESSAGE.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EBMS when CPAId is valid and accepted type" {
+        val forwardingSystem = PAYLOAD_MESSAGE.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EBMS
     }
 
-    "Returns EMOTTAK when CPAId is missing" {
-        val forwardingSystem = EBXML_NO_CPAID.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EMOTTAK when CPAId is missing" {
+        val forwardingSystem = EBXML_NO_CPAID.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
     }
 
-    "Returns EMOTTAK when CPAId is not accepted" {
-        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_CPAID.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EMOTTAK when CPAId is not accepted" {
+        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_CPAID.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
     }
 
-    "Returns EMOTTAK when Service Type is not accepted" {
-        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_SERVICE.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EMOTTAK when Service Type is not accepted" {
+        val forwardingSystem = PAYLOAD_MESSAGE_INVALID_SERVICE.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
     }
 
-    "Returns EMOTTAK when Service Type is not found" {
-        val forwardingSystem = EBXML_NO_SERVICE.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EMOTTAK when Service Type is not found" {
+        val forwardingSystem = EBXML_NO_SERVICE.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
     }
 
-    "Returns EMOTTAK when document is unparsable" {
-        val forwardingSystem = NOT_EBXML_MESSAGE.emlToEmailMsg().filterMimeMessage()
+    "getForwardingSystem returns EMOTTAK when document is unparsable" {
+        val forwardingSystem = NOT_EBXML_MESSAGE.emlToEmailMsg().getForwardingSystem()
         forwardingSystem shouldBe ForwardingSystem.EMOTTAK
     }
 

--- a/src/test/resources/testmail/ebxml_no_cpaid.eml
+++ b/src/test/resources/testmail/ebxml_no_cpaid.eml
@@ -1,0 +1,60 @@
+X-Original-To: nyebmsbcc@test-es.nav.no
+Delivered-To: nyebmsbcc@test-es.nav.no
+From: "no-reply@nav.no" <no-reply@nav.no>
+Date: Thu, 12 Feb 2026 12:00:38 +0000
+Subject: InntektsForesporsel
+Message-Id: <OO2R1I6MHSU4.L13WVN153AMT1@sender-7c6d6fb6c9-gnmwq>
+To: "mottak-qass@test-es.nav.no" <mottak-qass@test-es.nav.no>
+SOAPAction: "ebXML"
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="=-m/5aQmgtBfSwyFxBpLeITA=="
+
+--=-m/5aQmgtBfSwyFxBpLeITA==
+Content-Type: text/xml
+Content-Id: <ref0>
+Content-Transfer-Encoding: 7bit
+
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP:Envelope xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/">
+	<SOAP:Header>
+		<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+			<eb:From>
+				<eb:PartyId eb:type="commonname">DIPS test</eb:PartyId>
+				<eb:PartyId eb:type="orgnummer">979543883</eb:PartyId>
+				<eb:PartyId eb:type="DN">CN=DIPS test,O=DIPS AS,C=NO</eb:PartyId>
+				<eb:Role>Fordringshaver</eb:Role>
+			</eb:From>
+			<eb:To>
+				<eb:PartyId eb:type="commonname">ARBEIDS- OG VELFERDSETATEN TEST</eb:PartyId>
+				<eb:PartyId eb:type="orgnummer">889640782</eb:PartyId>
+				<eb:PartyId eb:type="DN">CN=ARBEIDS- OG VELFERDSETATEN TEST,O=ARBEIDS- OG VELFERDSETATEN,C=NO</eb:PartyId>
+				<eb:Role>Ytelsesutbetaler</eb:Role>
+			</eb:To>
+			<eb:ConversationId>c6d0b534-5d7b-4a8e-b549-fbfa1769302f</eb:ConversationId>
+			<eb:Service eb:type="string">Inntektsforesporsel</eb:Service>
+			<eb:Action>Foresporsel</eb:Action>
+			<eb:MessageData>
+				<eb:MessageId>35dde971-53c6-47fb-9a11-030c6aa4ef98</eb:MessageId>
+				<eb:Timestamp>2026-02-12T12:00:33</eb:Timestamp>
+			</eb:MessageData>
+			<eb:DuplicateElimination />
+			<eb:Description xml:lang="NO">{"MSH-system":"CFC","MSH-versjon":"7.8.28","fagsystem":"CFC Azure dev"}</eb:Description>
+		</eb:MessageHeader>
+		<eb:AckRequested SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH" SOAP:mustUnderstand="1" eb:signed="true" eb:version="2.0"> </eb:AckRequested>
+	<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" /><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116"><XPath xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">not(ancestor-or-self::node()[@SOAP-ENV:actor="urn:oasis:names:tc:ebxml-msg:actor:nextMSH"] | ancestor-or-self::node()[@SOAP-ENV:actor="http://schemas.xmlsoap.org/soap/actor/next"])</XPath></Transform><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" /><DigestValue>f52j77aLKHOtAPcH1anJq8Z2K4fny2G3YEe7HF7ELQI=</DigestValue></Reference><Reference URI="cid:ref1"><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" /><DigestValue>qbH6TlEee+MSlzOXYnGvAkofgvFYDpXm4AdfQA1DwzY=</DigestValue></Reference></SignedInfo><SignatureValue>DAhSZ9ZKk3kEhX8nVLZxYaSuQxGEzvg2S2b1vUN0+I0ArVyd6Dq+Cu/+OWEXS1OFWUZa73Ie/x8iCUpHqdhG6bsFsdJ6Pt/aLf9q9o/8ZPIsyR8dqAhlqBTNoYJIi9m/J3Ou4ITPbbcwX04hktZLIJ+tKLn8xz7rB+g5I5a0bcy/kdSJJU8pCJT+fwG9+JxCkYkgL2Rdobvyc9HaikKE2HdF+YOIGIflH5rBTtDmGkWPik6r0sDy/4f7pBh1sPFv6nJfDAfNbh4XMjIareQp7zci+WNdz0t0E+2sewUEGyM72/um4RlJopZ1q04qtQh81qscCsJ1RkksjQqkr1t4+r1ui/LgS8WnwX+aEisCQkeaG+CSmlUt/JqJU4+QC7FQWiygnI4VAFAv0qXcnzrYcN/TGJ4sMulrDl6uTHxH7NHKWSxyQIgmq/+wKX1HjOqyrom9xRLH+/V5HoIaSUK1IgZvmntpYX01HP21rFDc6Kkieu2eIYXRoFBFh5NAdqK4</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIGKTCCBBGgAwIBAgILAaHrm98F/7/YRCcwDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTI0MTAzMDE0MzkwOVoXDTI3MTAzMDIxNTkwMFowTTELMAkGA1UEBhMCTk8xEDAOBgNVBAoMB0RJUFMgQVMxEjAQBgNVBAMMCURJUFMgdGVzdDEYMBYGA1UEYQwPTlRSTk8tOTc5NTQzODgzMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzTnQaxvUpoGDrTAeq8cEhlX4uIlWqp3ZbZxiH8bPnVX0IxFDa3AhOyR1SW5kouR8IRc44uNdDEONaee56ongF0u7nj+bVtGDVap2JkLVRBxFi13jad0UhYJDsrzXnsy++W5HiGpf80Tawmp87lzU9rUxfl2uNKjgFYsQZACci4aTqQkfLzcqIW4HAxPZlZnuoObgKrF0T7FWgjO7/cQWLbLWEV7mL+iv6kLDDVOdPfvvh6+4z+f7JqChvq3+h6UBOLMP0LR0g+9NBoOPQHfMV7JAoIc/twdNJP7mfbAOslw+YHRRL4MbijX5pIwBUKcZHeeqMFeuk0qRgaMFL67Q1fWzJ4ZQfayuM1wwU07HPjUYCQ3nsfwLGQw6N9R9WIY36iyfsith+o8GOvKjsK3GhV0kBw3f+5aZCSnPMFncEYVBzupc7WhMRKL/rytu0g/LHryEafBoiY60s1r/cpCQ0ZGGY5Zvim5nx+KIyh6wcq0zjlwjMuDajWHgv5aft3lHAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBTqYifJES54fztLs+i69hIjJ5awdjAOBgNVHQ8BAf8EBAMCBkAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAHJlka2JOMGCiZp0AgJRUxymbnxKhyJrHpVbYm+sc8nJ5F9fwCMExVjzWFr7xHhrvywYUc1osPf1lnbNBe8nt1i1vXBgVwYXqWuxJR/Ezh3SBAe4QbpVBY0jxo/19P+NFjK0zpSvKIacBR/I1r2KhWWPE/vXCz6dRa3uo7j8Qk+9R+l7a171vOUetu3d0RsDbOn5C81hnN4nJypP5ij5AZyH0YqSTXz4U7LGGAlQza9zn2rPe+JWOToVyV4ojuAr++Niyc+D0fu6oGInqcREYBaRby690+r6L0ZvJQXDCk9v67KYc9UnBuKG8RHzTsUSe1WCC7cxsFyCQI2mzldbhKEOkM0dO6IJ/lQ0J5Me8gwEGx3jh2+YQNsI+NlJXps6jjkRp0TP5IK/Q/LaHdCBlRHt2o5+Hvnn8Zaj+bHkqwJc59zwfvkU7QYWRfzLP+01Kly4nngxFgXZ5KoWFCJhAQj5WZOcitGsOUoGadS8nHWa01WsRpC1nLcvKCN1fa21taYLgkcOTzA3iIdrhhr0+zbd6fk/Wm4cM4Rs50nMjigyXem/4Ztd1a6cVjOJNv6wfPHX7yiXgoY/N0UkcWb+PPJQRTUpOmWWYSDe/E1usKBjMTDPVAIZeXkpoxyzP7gXGIE4eJcH8bMh4wBZpy0a1MI9R1QMqlvqeBMI9KYLHAs6</X509Certificate></X509Data></KeyInfo></Signature></SOAP:Header>
+	<SOAP:Body>
+		<eb:Manifest eb:version="2.0">
+			<eb:Reference xlink:href="cid:ref1" xlink:type="simple" />
+		</eb:Manifest>
+	</SOAP:Body>
+</SOAP:Envelope>
+
+--=-m/5aQmgtBfSwyFxBpLeITA==
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data
+Content-Id: <ref1>
+Content-Transfer-Encoding: base64
+
+MIIfhQYJKoZIhvcNAQcDoIIfdjCCH3ICAQAxggIZMIICFQIBADB9MG4xCzAJBgNVBAYTAk5PMRgw
+SbS5CoPJjk1FFOzuE8teR4mV0MnTEirXep2YSvmpvU6mtn/Z
+
+--=-m/5aQmgtBfSwyFxBpLeITA==--

--- a/src/test/resources/testmail/inntektsforesporsel_invalid_cpaid.eml
+++ b/src/test/resources/testmail/inntektsforesporsel_invalid_cpaid.eml
@@ -1,0 +1,61 @@
+X-Original-To: nyebmsbcc@test-es.nav.no
+Delivered-To: nyebmsbcc@test-es.nav.no
+From: "no-reply@nav.no" <no-reply@nav.no>
+Date: Thu, 12 Feb 2026 12:00:38 +0000
+Subject: InntektsForesporsel
+Message-Id: <OO2R1I6MHSU4.L13WVN153AMT1@sender-7c6d6fb6c9-gnmwq>
+To: "mottak-qass@test-es.nav.no" <mottak-qass@test-es.nav.no>
+SOAPAction: "ebXML"
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="=-m/5aQmgtBfSwyFxBpLeITA=="
+
+--=-m/5aQmgtBfSwyFxBpLeITA==
+Content-Type: text/xml
+Content-Id: <ref0>
+Content-Transfer-Encoding: 7bit
+
+<?xml version="1.0" encoding="utf-8"?>
+<SOAP:Envelope xmlns:eb="http://www.oasis-open.org/committees/ebxml-msg/schema/msg-header-2_0.xsd" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:SOAP="http://schemas.xmlsoap.org/soap/envelope/">
+	<SOAP:Header>
+		<eb:MessageHeader SOAP:mustUnderstand="1" eb:version="2.0">
+			<eb:From>
+				<eb:PartyId eb:type="commonname">DIPS test</eb:PartyId>
+				<eb:PartyId eb:type="orgnummer">979543883</eb:PartyId>
+				<eb:PartyId eb:type="DN">CN=DIPS test,O=DIPS AS,C=NO</eb:PartyId>
+				<eb:Role>Fordringshaver</eb:Role>
+			</eb:From>
+			<eb:To>
+				<eb:PartyId eb:type="commonname">ARBEIDS- OG VELFERDSETATEN TEST</eb:PartyId>
+				<eb:PartyId eb:type="orgnummer">889640782</eb:PartyId>
+				<eb:PartyId eb:type="DN">CN=ARBEIDS- OG VELFERDSETATEN TEST,O=ARBEIDS- OG VELFERDSETATEN,C=NO</eb:PartyId>
+				<eb:Role>Ytelsesutbetaler</eb:Role>
+			</eb:To>
+			<eb:CPAId>nav:12345</eb:CPAId>
+			<eb:ConversationId>c6d0b534-5d7b-4a8e-b549-fbfa1769302f</eb:ConversationId>
+			<eb:Service eb:type="string">Inntektsforesporsel</eb:Service>
+			<eb:Action>Foresporsel</eb:Action>
+			<eb:MessageData>
+				<eb:MessageId>35dde971-53c6-47fb-9a11-030c6aa4ef98</eb:MessageId>
+				<eb:Timestamp>2026-02-12T12:00:33</eb:Timestamp>
+			</eb:MessageData>
+			<eb:DuplicateElimination />
+			<eb:Description xml:lang="NO">{"MSH-system":"CFC","MSH-versjon":"7.8.28","fagsystem":"CFC Azure dev"}</eb:Description>
+		</eb:MessageHeader>
+		<eb:AckRequested SOAP:actor="urn:oasis:names:tc:ebxml-msg:actor:toPartyMSH" SOAP:mustUnderstand="1" eb:signed="true" eb:version="2.0"> </eb:AckRequested>
+	<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" /><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" /><Reference URI=""><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" /><Transform Algorithm="http://www.w3.org/TR/1999/REC-xpath-19991116"><XPath xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">not(ancestor-or-self::node()[@SOAP-ENV:actor="urn:oasis:names:tc:ebxml-msg:actor:nextMSH"] | ancestor-or-self::node()[@SOAP-ENV:actor="http://schemas.xmlsoap.org/soap/actor/next"])</XPath></Transform><Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" /></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" /><DigestValue>f52j77aLKHOtAPcH1anJq8Z2K4fny2G3YEe7HF7ELQI=</DigestValue></Reference><Reference URI="cid:ref1"><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" /><DigestValue>qbH6TlEee+MSlzOXYnGvAkofgvFYDpXm4AdfQA1DwzY=</DigestValue></Reference></SignedInfo><SignatureValue>DAhSZ9ZKk3kEhX8nVLZxYaSuQxGEzvg2S2b1vUN0+I0ArVyd6Dq+Cu/+OWEXS1OFWUZa73Ie/x8iCUpHqdhG6bsFsdJ6Pt/aLf9q9o/8ZPIsyR8dqAhlqBTNoYJIi9m/J3Ou4ITPbbcwX04hktZLIJ+tKLn8xz7rB+g5I5a0bcy/kdSJJU8pCJT+fwG9+JxCkYkgL2Rdobvyc9HaikKE2HdF+YOIGIflH5rBTtDmGkWPik6r0sDy/4f7pBh1sPFv6nJfDAfNbh4XMjIareQp7zci+WNdz0t0E+2sewUEGyM72/um4RlJopZ1q04qtQh81qscCsJ1RkksjQqkr1t4+r1ui/LgS8WnwX+aEisCQkeaG+CSmlUt/JqJU4+QC7FQWiygnI4VAFAv0qXcnzrYcN/TGJ4sMulrDl6uTHxH7NHKWSxyQIgmq/+wKX1HjOqyrom9xRLH+/V5HoIaSUK1IgZvmntpYX01HP21rFDc6Kkieu2eIYXRoFBFh5NAdqK4</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIGKTCCBBGgAwIBAgILAaHrm98F/7/YRCcwDQYJKoZIhvcNAQELBQAwbjELMAkGA1UEBhMCTk8xGDAWBgNVBGEMD05UUk5PLTk4MzE2MzMyNzETMBEGA1UECgwKQnV5cGFzcyBBUzEwMC4GA1UEAwwnQnV5cGFzcyBDbGFzcyAzIFRlc3Q0IENBIEcyIFNUIEJ1c2luZXNzMB4XDTI0MTAzMDE0MzkwOVoXDTI3MTAzMDIxNTkwMFowTTELMAkGA1UEBhMCTk8xEDAOBgNVBAoMB0RJUFMgQVMxEjAQBgNVBAMMCURJUFMgdGVzdDEYMBYGA1UEYQwPTlRSTk8tOTc5NTQzODgzMIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAzTnQaxvUpoGDrTAeq8cEhlX4uIlWqp3ZbZxiH8bPnVX0IxFDa3AhOyR1SW5kouR8IRc44uNdDEONaee56ongF0u7nj+bVtGDVap2JkLVRBxFi13jad0UhYJDsrzXnsy++W5HiGpf80Tawmp87lzU9rUxfl2uNKjgFYsQZACci4aTqQkfLzcqIW4HAxPZlZnuoObgKrF0T7FWgjO7/cQWLbLWEV7mL+iv6kLDDVOdPfvvh6+4z+f7JqChvq3+h6UBOLMP0LR0g+9NBoOPQHfMV7JAoIc/twdNJP7mfbAOslw+YHRRL4MbijX5pIwBUKcZHeeqMFeuk0qRgaMFL67Q1fWzJ4ZQfayuM1wwU07HPjUYCQ3nsfwLGQw6N9R9WIY36iyfsith+o8GOvKjsK3GhV0kBw3f+5aZCSnPMFncEYVBzupc7WhMRKL/rytu0g/LHryEafBoiY60s1r/cpCQ0ZGGY5Zvim5nx+KIyh6wcq0zjlwjMuDajWHgv5aft3lHAgMBAAGjggFnMIIBYzAJBgNVHRMEAjAAMB8GA1UdIwQYMBaAFKf+u2xZiK10LkZeemj50bu/z7aLMB0GA1UdDgQWBBTqYifJES54fztLs+i69hIjJ5awdjAOBgNVHQ8BAf8EBAMCBkAwHwYDVR0gBBgwFjAKBghghEIBGgEDAjAIBgYEAI96AQEwQQYDVR0fBDowODA2oDSgMoYwaHR0cDovL2NybC50ZXN0NC5idXlwYXNzY2EuY29tL0JQQ2wzQ2FHMlNUQlMuY3JsMHsGCCsGAQUFBwEBBG8wbTAtBggrBgEFBQcwAYYhaHR0cDovL29jc3Bicy50ZXN0NC5idXlwYXNzY2EuY29tMDwGCCsGAQUFBzAChjBodHRwOi8vY3J0LnRlc3Q0LmJ1eXBhc3NjYS5jb20vQlBDbDNDYUcyU1RCUy5jZXIwJQYIKwYBBQUHAQMEGTAXMBUGCCsGAQUFBwsCMAkGBwQAi+xJAQIwDQYJKoZIhvcNAQELBQADggIBAHJlka2JOMGCiZp0AgJRUxymbnxKhyJrHpVbYm+sc8nJ5F9fwCMExVjzWFr7xHhrvywYUc1osPf1lnbNBe8nt1i1vXBgVwYXqWuxJR/Ezh3SBAe4QbpVBY0jxo/19P+NFjK0zpSvKIacBR/I1r2KhWWPE/vXCz6dRa3uo7j8Qk+9R+l7a171vOUetu3d0RsDbOn5C81hnN4nJypP5ij5AZyH0YqSTXz4U7LGGAlQza9zn2rPe+JWOToVyV4ojuAr++Niyc+D0fu6oGInqcREYBaRby690+r6L0ZvJQXDCk9v67KYc9UnBuKG8RHzTsUSe1WCC7cxsFyCQI2mzldbhKEOkM0dO6IJ/lQ0J5Me8gwEGx3jh2+YQNsI+NlJXps6jjkRp0TP5IK/Q/LaHdCBlRHt2o5+Hvnn8Zaj+bHkqwJc59zwfvkU7QYWRfzLP+01Kly4nngxFgXZ5KoWFCJhAQj5WZOcitGsOUoGadS8nHWa01WsRpC1nLcvKCN1fa21taYLgkcOTzA3iIdrhhr0+zbd6fk/Wm4cM4Rs50nMjigyXem/4Ztd1a6cVjOJNv6wfPHX7yiXgoY/N0UkcWb+PPJQRTUpOmWWYSDe/E1usKBjMTDPVAIZeXkpoxyzP7gXGIE4eJcH8bMh4wBZpy0a1MI9R1QMqlvqeBMI9KYLHAs6</X509Certificate></X509Data></KeyInfo></Signature></SOAP:Header>
+	<SOAP:Body>
+		<eb:Manifest eb:version="2.0">
+			<eb:Reference xlink:href="cid:ref1" xlink:type="simple" />
+		</eb:Manifest>
+	</SOAP:Body>
+</SOAP:Envelope>
+
+--=-m/5aQmgtBfSwyFxBpLeITA==
+Content-Type: application/pkcs7-mime; smime-type=enveloped-data
+Content-Id: <ref1>
+Content-Transfer-Encoding: base64
+
+MIIfhQYJKoZIhvcNAQcDoIIfdjCCH3ICAQAxggIZMIICFQIBADB9MG4xCzAJBgNVBAYTAk5PMRgw
+SbS5CoPJjk1FFOzuE8teR4mV0MnTEirXep2YSvmpvU6mtn/Z
+
+--=-m/5aQmgtBfSwyFxBpLeITA==--


### PR DESCRIPTION
Istedenfor å starte filtrering på avsender-epost, så gjøres det nå et forsøk på å hente ut CPA-id og Service fra ebXML-meldingen. Deretter brukes denne informasjonen til å route meldinger til ønsket system.

https://github.com/navikt/team-emottak-docs/issues/338