### PR TITLE
Mer kontroll på aktivering og deaktivering av epostlesing

### DIFF
--- a/.nais/smtp-transport-dev.yaml
+++ b/.nais/smtp-transport-dev.yaml
@@ -110,5 +110,7 @@ spec:
       value: "true"
     - name: SMTP_READ_INTERVAL
       value: "30s"
+    - name: SMTP_READ_INITIAL_DELAY
+      value: "0s"
     - name: INBOX_BATCH_READ_LIMIT
       value: "10"

--- a/.nais/smtp-transport-dev.yaml
+++ b/.nais/smtp-transport-dev.yaml
@@ -58,6 +58,7 @@ spec:
     pool: nav-dev
   envFrom:
     - secret: smtp-transport-secrets
+    - configmap: smtp-transport-config
   vault:
     enabled: true
     paths:
@@ -108,9 +109,3 @@ spec:
       value: "DEBUG"
     - name: INBOX_EXPUNGE
       value: "true"
-    - name: SMTP_READ_INTERVAL
-      value: "5s"
-    - name: SMTP_READ_INITIAL_DELAY
-      value: "0s"
-    - name: INBOX_BATCH_READ_LIMIT
-      value: "20"

--- a/.nais/smtp-transport-prod.yaml
+++ b/.nais/smtp-transport-prod.yaml
@@ -55,6 +55,7 @@ spec:
     pool: nav-prod
   envFrom:
     - secret: smtp-transport-secrets
+    - configmap: smtp-transport-config
   vault:
     enabled: true
     paths:
@@ -98,9 +99,3 @@ spec:
       value: "emottak-smtp-transport-payload-admin"
     - name: INBOX_EXPUNGE
       value: "true"
-    - name: SMTP_READ_INTERVAL
-      value: "30s"
-    - name: SMTP_READ_INITIAL_DELAY
-      value: "5s"
-    - name: INBOX_BATCH_READ_LIMIT
-      value: "20"

--- a/.nais/smtp-transport-prod.yaml
+++ b/.nais/smtp-transport-prod.yaml
@@ -100,5 +100,7 @@ spec:
       value: "true"
     - name: SMTP_READ_INTERVAL
       value: "30s"
+    - name: SMTP_READ_INITIAL_DELAY
+      value: "5s"
     - name: INBOX_BATCH_READ_LIMIT
       value: "20"

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -13,6 +13,7 @@ import io.ktor.utils.io.CancellationException
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
 import no.nav.emottak.plugin.configureAuthentication
 import no.nav.emottak.plugin.configureCallLogging
@@ -32,9 +33,12 @@ import no.nav.emottak.util.eventLoggingService
 import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
 
 internal val log = LoggerFactory.getLogger("no.nav.emottak.smtp")
+val mailReaderActive = AtomicBoolean(true)
 
 fun main() = SuspendApp {
     result {
@@ -101,11 +105,20 @@ internal fun smtpTransportModule(
 
 private suspend fun ResourceScope.scheduleProcessMailMessages(processor: MailProcessor): Long {
     val scope = coroutineScope(coroutineContext)
+    val initialDelay = config().job.initialDelay
+    if (initialDelay > Duration.ZERO) {
+        log.info("Delaying initial mail processing by $initialDelay")
+        delay(initialDelay)
+    }
     return Schedule
         .spaced<Unit>(config().job.fixedInterval)
         .repeat {
             val start = Clock.System.now()
-            processor.processMessages(scope)
+            if (mailReaderActive.get()) {
+                processor.processMessages(scope)
+            } else {
+                log.info("Mail reading is disabled, reactivate to process messages")
+            }
             log.info("Scheduled message batch executed in ${(Clock.System.now() - start).inWholeMilliseconds} ms")
         }
 }

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -26,7 +26,10 @@ data class Config(
 
 fun Config.withKafka(update: Kafka.() -> Kafka) = copy(kafka = kafka.update())
 
-data class Job(val fixedInterval: Duration)
+data class Job(
+    val fixedInterval: Duration,
+    val initialDelay: Duration
+)
 
 data class Mail(
     val inboxLimit: Int,

--- a/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
@@ -50,11 +50,11 @@ fun Application.configureRoutes(
 fun Route.mailReaderActivationRoutes() {
     get("/mail/incoming/activate") {
         mailReaderActive.set(true)
-        call.respondText { "Mail reading activated! :)" }
+        call.respondText { "Mail reading activated! 👀" }
     }
     get("/mail/incoming/deactivate") {
         mailReaderActive.set(false)
-        call.respondText { "Mail reading deactivated! :(" }
+        call.respondText { "Mail reading deactivated! 😭" }
     }
 }
 

--- a/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
@@ -12,6 +12,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
@@ -23,6 +24,7 @@ import no.nav.emottak.ReferenceIdEmpty
 import no.nav.emottak.ReferenceIdMissing
 import no.nav.emottak.RetrievePayloadError
 import no.nav.emottak.config
+import no.nav.emottak.mailReaderActive
 import no.nav.emottak.model.Payload
 import no.nav.emottak.repository.PayloadRepository
 import no.nav.emottak.toContent
@@ -39,9 +41,21 @@ fun Application.configureRoutes(
     val config = config()
     routing {
         internalRoutes(registry)
+        mailReaderActivationRoutes()
         authenticate(config.azureAuth.azureAdAuth.value) {
             externalRoutes(payloadRepository)
         }
+    }
+}
+
+fun Route.mailReaderActivationRoutes() {
+    get("/mail/incoming/activate") {
+        mailReaderActive.set(true)
+        call.respondText { "Mail reading activated! :)" }
+    }
+    get("/mail/incoming/deactivate") {
+        mailReaderActive.set(false)
+        call.respondText { "Mail reading deactivated! :(" }
     }
 }
 

--- a/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/emottak/plugin/Routes.kt
@@ -12,7 +12,6 @@ import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
-import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 job {
   fixedInterval = "${SMTP_READ_INTERVAL:-1m}"
+  initialDelay = "${SMTP_READ_INITIAL_DELAY:-0s}"
 }
 
 mail {


### PR DESCRIPTION
- Configstyrt forsinkelse på epostlesing ved oppstart
- Endepunkt for å aktivere/deaktivere epostlesing i runtime

Flyttet config for epostlesing til configmap i nais console for å slippe bygg og deploy ved endring
- Prod: https://console.nav.cloud.nais.io/team/team-emottak/prod-fss/config/smtp-transport-config
- Dev: https://console.nav.cloud.nais.io/team/team-emottak/dev-fss/config/smtp-transport-config