### PR TITLE
Mulighet for å styre lesing av inbox via config

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -37,7 +37,7 @@ import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 
 internal val log = LoggerFactory.getLogger("no.nav.emottak.smtp")
-val mailReaderActive = AtomicBoolean(true)
+val mailReaderActive = AtomicBoolean(config().mail.inboxReadActive)
 
 fun main() = SuspendApp {
     result {

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -35,7 +35,8 @@ data class Mail(
     val inboxLimit: Int,
     val inboxBatchReadLimit: Int,
     val inboxExpunge: Boolean,
-    val inboxWarningThreshold: Int
+    val inboxWarningThreshold: Int,
+    val inboxReadActive: Boolean
 )
 
 data class EbmsAsync(val baseUrl: String, val apiUrl: String)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,6 +8,7 @@ mail {
   inboxBatchReadLimit = "${INBOX_BATCH_READ_LIMIT:-10}"
   inboxExpunge = "${INBOX_EXPUNGE:-false}"
   inboxWarningThreshold = "${INBOX_WARNING_THRESHOLD:-100}"
+  inboxReadActive = "${INBOX_READ_ACTIVE:-true}"
 }
 
 server {


### PR DESCRIPTION
Kan styres ved konfig `INBOX_READ_ACTIVE` i nais console, slik at det er mulig å skru den av på tvers av container-restarts. Dette kan være nyttig i tilfeller ved vedlikehold eller CrashLoopBackoffs.