### PR TITLE
Slå av forrige pods lesing før deploy

### DIFF
--- a/.nais/smtp-transport-dev.yaml
+++ b/.nais/smtp-transport-dev.yaml
@@ -77,6 +77,8 @@ spec:
           namespace: aura
           cluster: dev-gcp
   env:
+    - name: SMTP_STOP_URL
+    - value: "https://smtp-transport.intern.dev.nav.no/mail/incoming/deactivate"
     - name: SMTP_HOST
       value: "d32mxvl002.oera-t.local"
     - name: SMTP_PORT

--- a/.nais/smtp-transport-prod.yaml
+++ b/.nais/smtp-transport-prod.yaml
@@ -69,6 +69,8 @@ spec:
       rules:
         - application: ebms-async
   env:
+    - name: SMTP_STOP_URL
+      value: "https://smtp-transport.intern.nav.no/mail/incoming/deactivate"
     - name: SMTP_HOST
       value: "a30mxvl002.oera.no"
     - name: SMTP_PORT

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -51,15 +51,17 @@ fun main() = SuspendApp {
             log.info("Starting flyway migrations...")
             deps.migrationService.migrate()
             log.info("Flyway migration successfully.")
-            log.info("Deactivating old pod process...")
-            deps.httpClient.get(config().smtp.smtpStopUrl)
-                .also {
-                    if (it.status.isSuccess()) {
-                        log.info("Deactivation successful: " + it.bodyAsText())
-                    } else {
-                        log.warn("Deactivation unsuccesful: " + it.bodyAsText())
+            if(!config().smtp.smtpStopUrl.contains("localhost")) {
+                log.info("Deactivating old pod process...")
+                deps.httpClient.get(config().smtp.smtpStopUrl)
+                    .also {
+                        if (it.status.isSuccess()) {
+                            log.info("Deactivation successful: " + it.bodyAsText())
+                        } else {
+                            log.warn("Deactivation unsuccesful: " + it.bodyAsText())
+                        }
                     }
-                }
+            }
             val scope = coroutineScope(coroutineContext)
             val eventScope = coroutineScope(Dispatchers.IO)
             val eventLoggingService = eventLoggingService(

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -7,6 +7,8 @@ import arrow.fx.coroutines.ResourceScope
 import arrow.fx.coroutines.autoCloseable
 import arrow.fx.coroutines.resourceScope
 import arrow.resilience.Schedule
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
@@ -48,7 +50,11 @@ fun main() = SuspendApp {
             log.info("Starting flyway migrations...")
             deps.migrationService.migrate()
             log.info("Flyway migration successfully.")
-
+            log.info("Deactivating old pod process...")
+            deps.httpClient.get (config().smtp.smtpStopUrl)
+                .also {
+                    log.info("Deactivation response: " + it.bodyAsText())
+                }
             val scope = coroutineScope(coroutineContext)
             val eventScope = coroutineScope(Dispatchers.IO)
             val eventLoggingService = eventLoggingService(

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -51,7 +51,7 @@ fun main() = SuspendApp {
             log.info("Starting flyway migrations...")
             deps.migrationService.migrate()
             log.info("Flyway migration successfully.")
-            if(!config().smtp.smtpStopUrl.contains("localhost")) {
+            if (!config().smtp.smtpStopUrl.contains("localhost")) {
                 log.info("Deactivating old pod process...")
                 deps.httpClient.get(config().smtp.smtpStopUrl)
                     .also {

--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -9,6 +9,7 @@ import arrow.fx.coroutines.resourceScope
 import arrow.resilience.Schedule
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
 import io.ktor.utils.io.CancellationException
@@ -51,9 +52,13 @@ fun main() = SuspendApp {
             deps.migrationService.migrate()
             log.info("Flyway migration successfully.")
             log.info("Deactivating old pod process...")
-            deps.httpClient.get (config().smtp.smtpStopUrl)
+            deps.httpClient.get(config().smtp.smtpStopUrl)
                 .also {
-                    log.info("Deactivation response: " + it.bodyAsText())
+                    if (it.status.isSuccess()) {
+                        log.info("Deactivation successful: " + it.bodyAsText())
+                    } else {
+                        log.warn("Deactivation unsuccesful: " + it.bodyAsText())
+                    }
                 }
             val scope = coroutineScope(coroutineContext)
             val eventScope = coroutineScope(Dispatchers.IO)

--- a/src/main/kotlin/no/nav/emottak/configuration/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/configuration/Config.kt
@@ -65,6 +65,7 @@ value class Protocol(val value: String)
 data class Smtp(
     val username: Username,
     val password: Masked,
+    val smtpStopUrl: String,
     val smtpPort: Port,
     val smtpHost: Host,
     val pop3Port: Port,

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -46,6 +46,7 @@ kafkaTopics {
 smtp {
   username = "${SMTP_INCOMING_USERNAME:-test@test.test}"
   password = "${SMTP_PASSWORD:-changeit}"
+  smtpStopUrl = "${SMTP_STOP_URL:-https://smtp-transport.intern.dev.nav.no/mail/incoming/deactivate}"
   smtpPort = "${SMTP_PORT:-3025}"
   pop3Port = "${SMTP_POP3_PORT:-3110}"
   smtpHost = "${SMTP_HOST:-localhost}"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -46,7 +46,7 @@ kafkaTopics {
 smtp {
   username = "${SMTP_INCOMING_USERNAME:-test@test.test}"
   password = "${SMTP_PASSWORD:-changeit}"
-  smtpStopUrl = "${SMTP_STOP_URL:-https://smtp-transport.intern.dev.nav.no/mail/incoming/deactivate}"
+  smtpStopUrl = "${SMTP_STOP_URL:-http://localhost}"
   smtpPort = "${SMTP_PORT:-3025}"
   pop3Port = "${SMTP_POP3_PORT:-3110}"
   smtpHost = "${SMTP_HOST:-localhost}"


### PR DESCRIPTION
Sender et deaktiveringssignal til forrige pod før den initialiserer readiness endepunkt.

I første omgang tenker jeg dette er OK. 
Kan se an om den trenger å verifisere at forrige har slått av og om den også da ikke svarer ready før den har klart å få isConnected() == true på store.