### PR TITLE
Metrikker for antall mottatte og sendte meldinger

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -75,14 +75,15 @@ fun main() = SuspendApp {
             val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient, eventLoggingService)
             val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
             val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
-            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService, config().smtp) }
+            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService, config().smtp, deps.meterRegistry) }
             val mailProcessor = MailProcessor(
                 deps.store,
                 mailPublisher,
                 payloadRepository,
                 eventLoggingService,
                 mailSender,
-                config().mail
+                config().mail,
+                deps.meterRegistry
             )
             val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 

--- a/src/main/kotlin/no/nav/emottak/SmtpMetrics.kt
+++ b/src/main/kotlin/no/nav/emottak/SmtpMetrics.kt
@@ -1,0 +1,37 @@
+package no.nav.emottak
+
+import io.micrometer.core.instrument.MeterRegistry
+import no.nav.emottak.smtp.ForwardableMimeMessage
+
+const val MESSAGES_RECEIVED_COUNTER = "smtp_transport_messages_received_total"
+const val TAG_FORWARDING_SYSTEM = "forwarding_system"
+const val TAG_SERVICE = "service"
+const val TAG_ACTION = "action"
+
+fun MeterRegistry.incrementMessagesReceived(forwardableMimeMessage: ForwardableMimeMessage) =
+    counter(
+        MESSAGES_RECEIVED_COUNTER,
+        TAG_FORWARDING_SYSTEM,
+        forwardableMimeMessage.forwardingSystem.name,
+        TAG_SERVICE,
+        forwardableMimeMessage.service,
+        TAG_ACTION,
+        forwardableMimeMessage.action
+    ).increment()
+
+const val MESSAGES_SENT_COUNTER = "smtp_transport_messages_sent_total"
+const val TAG_MESSAGE_TYPE = "message_type"
+const val TAG_SENDER_ADDRESS = "sender_address"
+
+fun MeterRegistry.incrementMessagesSent(messageType: String, service: String, action: String, senderAddress: String) =
+    counter(
+        MESSAGES_SENT_COUNTER,
+        TAG_MESSAGE_TYPE,
+        messageType,
+        TAG_SERVICE,
+        service,
+        TAG_ACTION,
+        action,
+        TAG_SENDER_ADDRESS,
+        senderAddress
+    ).increment()

--- a/src/main/kotlin/no/nav/emottak/model/MailMetadata.kt
+++ b/src/main/kotlin/no/nav/emottak/model/MailMetadata.kt
@@ -3,5 +3,7 @@ package no.nav.emottak.model
 data class MailMetadata(
     val recipientAddress: String,
     val subject: String = "",
-    val senderAddress: String
+    val senderAddress: String,
+    val service: String = "",
+    val action: String = ""
 )

--- a/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.processor
 
 import arrow.autoCloseScope
 import arrow.core.raise.fold
+import io.micrometer.core.instrument.MeterRegistry
 import jakarta.mail.Store
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -12,6 +13,7 @@ import kotlinx.datetime.Clock
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers
 import no.nav.emottak.configuration.Mail
+import no.nav.emottak.incrementMessagesReceived
 import no.nav.emottak.log
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
@@ -32,7 +34,8 @@ class MailProcessor(
     private val payloadRepository: PayloadRepository,
     private val eventLoggingService: ScopedEventLoggingService,
     private val mailSender: MailSender,
-    private val mail: Mail
+    private val mail: Mail,
+    private val meterRegistry: MeterRegistry
 ) {
 
     enum class InboxStatus {
@@ -97,7 +100,8 @@ class MailProcessor(
 
     private suspend fun processMessage(emailMsg: EmailMsg) {
         val start = Clock.System.now()
-        when (emailMsg.forwardableMimeMessage.forwardingSystem) {
+        val forwardableMimeMessage = emailMsg.forwardableMimeMessage
+        when (forwardableMimeMessage.forwardingSystem) {
             ForwardingSystem.EBMS -> publishToKafka(emailMsg)
             ForwardingSystem.EMOTTAK -> forwardToT1(emailMsg)
             ForwardingSystem.BOTH -> {
@@ -105,12 +109,16 @@ class MailProcessor(
                 forwardToT1(emailMsg)
             }
         }
+        meterRegistry.incrementMessagesReceived(forwardableMimeMessage)
         val marker: LogstashMarker = Markers.appendEntries(
             mapOf(
                 "requestId" to emailMsg.requestId.toString(),
                 "smtpSender" to emailMsg.senderAddress,
                 "smtpSubject" to (emailMsg.headers["Subject"] ?: "-"),
-                "forwardingSystem" to emailMsg.forwardableMimeMessage.forwardingSystem,
+                "forwardingSystem" to forwardableMimeMessage.forwardingSystem,
+                "service" to forwardableMimeMessage.service,
+                "cpaId" to forwardableMimeMessage.cpaId,
+                "action" to forwardableMimeMessage.action,
                 "sourceSystem" to (emailMsg.headers["X-Mailer"] ?: "-")
             )
         )

--- a/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/PayloadReceiver.kt
@@ -17,6 +17,7 @@ import no.nav.emottak.model.MailRoutingPayloadMessage
 import no.nav.emottak.model.Payload
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SoapWithAttachments
+import no.nav.emottak.util.EBXML_ACTION
 import no.nav.emottak.util.EBXML_SERVICE
 import no.nav.emottak.util.EMAIL_ADDRESSES
 import no.nav.emottak.util.EbmsAsyncClient
@@ -51,7 +52,9 @@ class PayloadReceiver(
         val mailMetadata = MailMetadata(
             recipientAddress = record.getHeaderValueAsString(EMAIL_ADDRESSES),
             subject = record.getHeaderValueAsString(EBXML_SERVICE),
-            senderAddress = record.getHeaderValueAsString(SENDER_ADDRESS)
+            senderAddress = record.getHeaderValueAsString(SENDER_ADDRESS),
+            service = record.getHeaderValueAsString(EBXML_SERVICE),
+            action = record.getHeaderValueAsString(EBXML_ACTION)
         )
 
         val referenceId = Uuid.parse(record.key())

--- a/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
+++ b/src/main/kotlin/no/nav/emottak/receiver/SignalReceiver.kt
@@ -11,6 +11,7 @@ import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MailRoutingSignalMessage
 import no.nav.emottak.model.SignalMessage
 import no.nav.emottak.util.EBXML_ACTION
+import no.nav.emottak.util.EBXML_SERVICE
 import no.nav.emottak.util.EMAIL_ADDRESSES
 import no.nav.emottak.util.SENDER_ADDRESS
 import no.nav.emottak.util.ScopedEventLoggingService
@@ -40,7 +41,9 @@ class SignalReceiver(
         val mailMetadata = MailMetadata(
             recipientAddress = record.getHeaderValueAsString(EMAIL_ADDRESSES),
             subject = record.getHeaderValueAsString(EBXML_ACTION),
-            senderAddress = record.getHeaderValueAsString(SENDER_ADDRESS)
+            senderAddress = record.getHeaderValueAsString(SENDER_ADDRESS),
+            service = record.getHeaderValueAsString(EBXML_SERVICE),
+            action = record.getHeaderValueAsString(EBXML_ACTION)
         )
         val signalMessage = SignalMessage(
             Uuid.parse(record.key()),

--- a/src/main/kotlin/no/nav/emottak/smtp/MailReader.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailReader.kt
@@ -31,7 +31,10 @@ data class EmailMsg(
 
 data class ForwardableMimeMessage(
     val forwardingSystem: ForwardingSystem,
-    val forwardableMimeMessage: MimeMessage?
+    val forwardableMimeMessage: MimeMessage?,
+    val service: String,
+    val cpaId: String,
+    val action: String
 )
 
 data class Part(

--- a/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
+++ b/src/main/kotlin/no/nav/emottak/smtp/MailSender.kt
@@ -1,6 +1,7 @@
 package no.nav.emottak.smtp
 
 import arrow.core.raise.catch
+import io.micrometer.core.instrument.MeterRegistry
 import jakarta.activation.DataHandler
 import jakarta.mail.Address
 import jakarta.mail.Message.RecipientType.TO
@@ -16,6 +17,7 @@ import jakarta.mail.util.ByteArrayDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.emottak.configuration.Smtp
+import no.nav.emottak.incrementMessagesSent
 import no.nav.emottak.log
 import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.MessageType
@@ -42,7 +44,8 @@ private const val ENCODING_BASE64 = "base64"
 class MailSender(
     private val session: Session,
     private val eventLoggingService: ScopedEventLoggingService,
-    private val smtp: Smtp
+    private val smtp: Smtp,
+    private val meterRegistry: MeterRegistry
 ) : Closeable {
     private val transport: Transport = session.getTransport("smtp")
 
@@ -74,19 +77,26 @@ class MailSender(
     suspend fun sendSignalMessage(metadata: MailMetadata, signalMessage: SignalMessage) =
         sendMessage(
             createMimeMessage(metadata, signalMessage),
-            SIGNAL
+            SIGNAL,
+            metadata.service,
+            metadata.action,
+            metadata.senderAddress
         )
 
     suspend fun sendPayloadMessage(metadata: MailMetadata, payloadMessage: PayloadMessage) =
         sendMessage(
             createMimeMultipartMessage(metadata, payloadMessage),
-            PAYLOAD
+            PAYLOAD,
+            metadata.service,
+            metadata.action,
+            metadata.senderAddress
         )
 
-    private suspend fun sendMessage(wrapper: MimeMessageWrapper, messageType: MessageType) =
+    private suspend fun sendMessage(wrapper: MimeMessageWrapper, messageType: MessageType, service: String, action: String, senderAddress: String) =
         withContext(Dispatchers.IO) {
             catch({
                 sendSynchronized(wrapper.mimeMessage, wrapper.mimeMessage.allRecipients)
+                meterRegistry.incrementMessagesSent(messageType.name, service, action, senderAddress)
                 eventLoggingService.registerEvent(
                     MESSAGE_SENT_VIA_SMTP,
                     wrapper.mimeMessage,

--- a/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
+++ b/src/main/kotlin/no/nav/emottak/util/EmailMsgFilter.kt
@@ -19,19 +19,30 @@ private val typesToBoth = config().ebmsFilter.typesToBoth
 private val cpaIds = config().ebmsFilter.cpaId
 
 fun EmailMsg.filterMessageForwarding(): ForwardableMimeMessage {
-    return when (val forwardingSystem = this.getForwardingSystem()) {
-        ForwardingSystem.EBMS -> ForwardableMimeMessage(forwardingSystem, null)
-        ForwardingSystem.EMOTTAK -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
-        ForwardingSystem.BOTH -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage))
+    val (forwardingSystem, service, cpaId, action) = this.computeForwardingDecision()
+    return when (forwardingSystem) {
+        ForwardingSystem.EBMS -> ForwardableMimeMessage(forwardingSystem, null, service, cpaId, action)
+        ForwardingSystem.EMOTTAK -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage), service, cpaId, action)
+        ForwardingSystem.BOTH -> ForwardableMimeMessage(forwardingSystem, MimeMessage(originalMimeMessage), service, cpaId, action)
     }
 }
 
-fun EmailMsg.getForwardingSystem(): ForwardingSystem {
+fun EmailMsg.getForwardingSystem(): ForwardingSystem = computeForwardingDecision().forwardingSystem
+
+private data class ForwardingDecision(
+    val forwardingSystem: ForwardingSystem,
+    val service: String,
+    val cpaId: String,
+    val action: String
+)
+
+private fun EmailMsg.computeForwardingDecision(): ForwardingDecision {
     val ebxmlDocument = getEnvelope().toXmlDocument()
     val envelopeServiceName = ebxmlDocument?.getEbxmlServiceName() ?: "UnparsableService"
     val envelopeCpaId = ebxmlDocument?.getEbxmlCpaId() ?: "UnparsableCpaId"
+    val envelopeAction = ebxmlDocument?.getEbxmlAction() ?: "UnparsableAction"
 
-    return if (isAcceptedCpaId(envelopeCpaId)) {
+    val forwardingSystem = if (isAcceptedCpaId(envelopeCpaId)) {
         if (typesToBoth.contains(envelopeServiceName)) {
             ForwardingSystem.BOTH
         } else if (typesToEbms.contains(envelopeServiceName)) {
@@ -41,20 +52,23 @@ fun EmailMsg.getForwardingSystem(): ForwardingSystem {
         }
     } else {
         ForwardingSystem.EMOTTAK
-    }.also {
-        val marker: LogstashMarker = Markers.appendEntries(
-            mapOf(
-                "requestId" to this.requestId.toString(),
-                "smtpSender" to this.senderAddress,
-                "smtpSubject" to (this.headers["Subject"] ?: "-"),
-                "service" to envelopeServiceName,
-                "cpaId" to envelopeCpaId,
-                "forwardingSystem" to it,
-                "sourceSystem" to (this.headers["X-Mailer"] ?: "-")
-            )
-        )
-        log.info(marker, "Message forwarding system identified")
     }
+
+    val marker: LogstashMarker = Markers.appendEntries(
+        mapOf(
+            "requestId" to this.requestId.toString(),
+            "smtpSender" to this.senderAddress,
+            "smtpSubject" to (this.headers["Subject"] ?: "-"),
+            "service" to envelopeServiceName,
+            "cpaId" to envelopeCpaId,
+            "action" to envelopeAction,
+            "forwardingSystem" to forwardingSystem,
+            "sourceSystem" to (this.headers["X-Mailer"] ?: "-")
+        )
+    )
+    log.info(marker, "Message forwarding system identified")
+
+    return ForwardingDecision(forwardingSystem, envelopeServiceName, envelopeCpaId, envelopeAction)
 }
 
 private fun isAcceptedCpaId(cpaId: String) = cpaIds.any { it.equals(cpaId, ignoreCase = true) }
@@ -76,6 +90,7 @@ private fun ByteArray.toXmlDocument(): Document? {
 
 private fun Document.getEbxmlServiceName(): String = this.getXmlElementValue("Service")
 private fun Document.getEbxmlCpaId(): String = this.getXmlElementValue("CPAId")
+private fun Document.getEbxmlAction(): String = this.getXmlElementValue("Action")
 
 private fun Document.getXmlElementValue(elementName: String): String {
     return try {

--- a/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
+++ b/src/main/kotlin/no/nav/emottak/util/KafkaUtil.kt
@@ -10,6 +10,6 @@ const val SENDER_ADDRESS = "senderAddress"
 
 fun <K, V> ReceiverRecord<K, V>.getHeaderValueAsString(value: String): String =
     when (val header = headers().lastHeader(value)) {
-        null -> "".also { log.warn("Kafka header missing: $value") }
+        null -> "".also { log.info("Kafka header missing: $value") }
         else -> String(header.value())
     }

--- a/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailReaderSpec.kt
@@ -6,6 +6,8 @@ import com.icegreen.greenmail.util.ServerSetupTest.SMTP_POP3
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
 import jakarta.mail.internet.MimeMessage
 import no.nav.emottak.config
 import no.nav.emottak.session
@@ -53,7 +55,7 @@ class MailReaderSpec : StringSpec({
 
             greenMail.receivedMessages.size shouldBe 3
 
-            val mailSender = MailSender(session, fakeEventLoggingService(), config.smtp)
+            val mailSender = MailSender(session, fakeEventLoggingService(), config.smtp, PrometheusMeterRegistry(PrometheusConfig.DEFAULT))
 
             mailSender.rawForward(greenMail.receivedMessages[0])
 

--- a/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/smtp/MailSenderSpec.kt
@@ -6,6 +6,8 @@ import com.icegreen.greenmail.util.ServerSetupTest.SMTP_POP3
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.micrometer.prometheus.PrometheusConfig
+import io.micrometer.prometheus.PrometheusMeterRegistry
 import no.nav.emottak.config
 import no.nav.emottak.model.MailMetadata
 import no.nav.emottak.model.Payload
@@ -26,7 +28,7 @@ class MailSenderSpec : StringSpec({
             start()
             setUser(config.smtp.username.value, config.smtp.username.value, config.smtp.password.value)
         }
-        mailSender = MailSender(session, fakeEventLoggingService(), config.smtp)
+        mailSender = MailSender(session, fakeEventLoggingService(), config.smtp, PrometheusMeterRegistry(PrometheusConfig.DEFAULT))
     }
 
     afterEach {


### PR DESCRIPTION
To nye metrikker tilgjengelig for promethues/grafana.

**smtp_transport_messages_received_total**
Teller innkommende e-poster etter at rutingbeslutning er tatt. Har følgende tags:
 - forwarding_system – hvor meldingen rutes (EBMS, EMOTTAK, BOTH)
 - service – ebXML Service-navn fra meldingskuvert
 - action – ebXML Action fra meldingskuvert

**smtp_transport_messages_sent_total**
Teller utgående e-poster etter vellykket SMTP-sending. Har følgende tags:
 - message_type – type melding (SIGNAL, PAYLOAD) (indikerer hvilken topic meldingen kom fra)
 - service – ebXML Service fra Kafka-headeren ebxmlService
 - action – ebXML Action fra Kafka-headeren ebxmlAction
 - sender_address – avsenderadresse fra Kafka-headeren senderAddress

Metrikkene: https://grafana.nav.cloud.nais.io/a/grafana-metricsdrilldown-app/drilldown?from=now-1h&to=now&timezone=browser&var-metrics_filters=&var-filters=&var-labelsWingman=%28none%29&layout=grid&filters-rule=&filters-prefix=&filters-suffix=&search_txt=smtp_transport_messages&var-metrics-reducer-sort-by=default&filters-recent=&var-ds=PA58DA793C7250F1B&var-other_metric_filters=

Foreløpig dashboard: https://grafana.nav.cloud.nais.io/d/thrzqrw/smtp-transport?orgId=1&from=now-6h&to=now&timezone=browser

Kan da også opprette alarmer når det **ikke** kommer noen meldinger innenfor en viss periode. 
