### PR TITLE
Flytt registrering av inboxSizeGauge for å unngå MeterFilter-warning

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -40,6 +40,7 @@ import no.nav.emottak.utils.kafka.client.EventPublisherClient
 import no.nav.emottak.utils.kafka.service.EventLoggingService
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -86,18 +87,6 @@ fun main() = SuspendApp {
             val payloadReceiver = PayloadReceiver(deps.kafkaReceiver, ebmsAsyncClient, eventLoggingService)
             val signalReceiver = SignalReceiver(deps.kafkaReceiver, eventLoggingService)
             val payloadRepository = PayloadRepository(deps.payloadDatabase, eventLoggingService)
-            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService, config().smtp, deps.meterRegistry) }
-            val mailProcessor = MailProcessor(
-                deps.store,
-                mailPublisher,
-                payloadRepository,
-                eventLoggingService,
-                mailSender,
-                config().mail,
-                deps.meterRegistry
-            )
-            val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
-
             val server = config().server
 
             server(
@@ -106,6 +95,22 @@ fun main() = SuspendApp {
                 preWait = server.preWait,
                 module = smtpTransportModule(deps.meterRegistry, payloadRepository)
             )
+
+            val inboxSize = AtomicInteger(0)
+            deps.meterRegistry.registerInboxSizeGauge(inboxSize)
+
+            val mailSender = autoCloseable { MailSender(deps.session, eventLoggingService, config().smtp, deps.meterRegistry) }
+            val mailProcessor = MailProcessor(
+                deps.store,
+                mailPublisher,
+                payloadRepository,
+                eventLoggingService,
+                mailSender,
+                config().mail,
+                deps.meterRegistry,
+                inboxSize
+            )
+            val messageProcessor = MessageProcessor(payloadReceiver, signalReceiver, mailSender)
 
             messageProcessor.processMailRoutingMessages(scope)
 

--- a/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
+++ b/src/main/kotlin/no/nav/emottak/processor/MailProcessor.kt
@@ -17,7 +17,6 @@ import no.nav.emottak.log
 import no.nav.emottak.model.PayloadMessage
 import no.nav.emottak.model.SignalMessage
 import no.nav.emottak.publisher.MailPublisher
-import no.nav.emottak.registerInboxSizeGauge
 import no.nav.emottak.repository.PayloadRepository
 import no.nav.emottak.smtp.EmailMsg
 import no.nav.emottak.smtp.MailReader
@@ -37,14 +36,9 @@ class MailProcessor(
     private val eventLoggingService: ScopedEventLoggingService,
     private val mailSender: MailSender,
     private val mail: Mail,
-    private val meterRegistry: MeterRegistry
+    private val meterRegistry: MeterRegistry,
+    private val inboxSize: AtomicInteger
 ) {
-
-    private val inboxSize = AtomicInteger(0)
-
-    init {
-        meterRegistry.registerInboxSizeGauge(inboxSize)
-    }
 
     enum class InboxStatus {
         EMPTY,


### PR DESCRIPTION
[Denne](https://grafana.nav.cloud.nais.io/goto/ffqayhhr6zgg0a?orgId=1) warningen logges ved oppstart. 
```
A MeterFilter is being configured after a Meter has been registered to this registry. 
All MeterFilters should be configured before any Meters are registered...
```
Dette burde fikse det ved å kalle `registerInboxSizeGauge(...)` etter oppstart av `server(...)`, som er når Ktor initialiserer alt med MicroMeter.
