### PR TITLE
Bumpet noen versjoner

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,12 +2,13 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     application
-    kotlin("jvm") version "2.3.21"
-    kotlin("plugin.serialization") version "2.3.21"
-    id("io.ktor.plugin") version "3.4.3"
+    val kotlinVersion = "2.4.10"
+    kotlin("jvm") version kotlinVersion
+    kotlin("plugin.serialization") version kotlinVersion
+    id("io.ktor.plugin") version "3.5.1"
     id("app.cash.sqldelight") version "2.0.2"
     id("org.jlleitschuh.gradle.ktlint") version "11.6.1"
-    id("com.gradleup.shadow") version "8.3.6"
+    id("com.gradleup.shadow") version "9.2.2"
 }
 
 sqldelight {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
             version("flyway", "9.16.3")
             version("hikari", "5.0.1")
             version("suspendapp", "0.5.0")
-            version("ktor", "3.4.3")
+            version("ktor", "3.5.1")
             version("token-validation-ktor", "5.0.30")
             version("jakarta-mail", "2.1.2")
             version("eclipse-angus", "2.0.2")
@@ -28,7 +28,7 @@ dependencyResolutionManagement {
             version("prometheus", "1.12.4")
             version("logback", "1.5.19")
             version("logstash", "7.4")
-            version("emottak-utils", "0.3.6")
+            version("emottak-utils", "0.5.0")
             version("bouncycastle", "1.82")
 
             library("arrow-core", "io.arrow-kt", "arrow-core").versionRef("arrow")
@@ -90,8 +90,8 @@ dependencyResolutionManagement {
         create("testLibs") {
             version("arrow", "2.0.0")
             version("testPostgres", "1.18.0")
-            version("ktor", "3.4.3")
-            version("ktor-server-test", "3.4.3")
+            version("ktor", "3.5.1")
+            version("ktor-server-test", "3.5.1")
             version("kotest", "5.9.1")
             version("mock-oauth2", "2.1.2")
             version("testcontainers", "1.21.4")

--- a/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
+++ b/src/main/kotlin/no/nav/emottak/util/ScopedEventLoggingService.kt
@@ -93,9 +93,13 @@ fun eventLoggingService(
             Instant.now()
         )
 
-        eventLoggingService.logEvent(event)
-            .onSuccess { log.debug("Event published successfully: {}", event) }
-            .onFailure { log.error("Error while publishing event: ${it.stackTraceToString()}") }
+        runCatching {
+            eventLoggingService.logEvent(event)
+        }.onSuccess {
+            log.debug("Event published successfully: {}", event)
+        }.onFailure { e ->
+            log.error("Error while publishing event: ${e.stackTraceToString()}")
+        }
     }
 }
 


### PR DESCRIPTION
- `kotlin` til versjon `2.4.10`.
- `ktor` til `3.5.1`.
- `com.gradleup.shadow` til `9.2.2`.
- `emottak-utils` til `0.5.0`.

Motivasjonen bak endringen er å kunne ta i bruk nyeste versjon av `emottak-utils`, som krever `kotlin 2.4`.

Denne erstatter https://github.com/navikt/smtp-transport/pull/141. 